### PR TITLE
MassExtractor can now handle dialog tables for Zones with an ID greater than 255.

### DIFF
--- a/MassExtractor/Program.cs
+++ b/MassExtractor/Program.cs
@@ -335,6 +335,10 @@ namespace MassExtractor
                     }
                     // Whitegate's 2nd dialog table
                     Program.ExtractFile(57945, "dialog-table-50-2.xml");
+                    for (ushort i = 0; i < 0x100; ++i)
+                    {
+                        Program.ExtractFile(85590 + i, String.Format("dialog-table-{0:000}.xml", i + 255));
+                    }
                     // Mob Lists
                     for (ushort i = 0; i < 0x100; ++i)
                     {


### PR DESCRIPTION
Question: I intend to add the new zones to the polutils menu's soon, should I hold off and come up with a  new category for the rhapsodies area's (there appear to be 2-3 more "escha" type zones incoming, from looking at dialog tables already in game) or just toss them in "other" for now?