### PR TITLE
Updated dat file mappings.

### DIFF
--- a/PlayOnline.FFXI.Utils.DataBrowser/ROMFileMappings.xml
+++ b/PlayOnline.FFXI.Utils.DataBrowser/ROMFileMappings.xml
@@ -1,3121 +1,3129 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
 // Copyright © 2004-2014 Tim Van Holder, Nevin Stepan, Windower Team
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
 // BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and limitations under the License.
 -->
 <rom-file-mappings>
-  <category><name><i18n-string id="Menu:DialogTables"/></name>
-    <!-- English: 06420-06675 -->
-    <category><name><i18n-string id="Menu:English"/></name>
-      <category><name>&amp;<i18n-string id="FFXI1"/></name>
-	<category><name><region-name id="000"/></name>
-	  <rom-file id="06653"><area-name id="233"/></rom-file>
-	  <rom-file id="06651"><area-name id="231"/></rom-file>
-	  <rom-file id="06652"><area-name id="232"/></rom-file>
-	  <rom-file id="06650"><area-name id="230"/></rom-file>
-	</category>
-	<category><name><region-name id="001"/></name>
-	  <rom-file id="06655"><area-name id="235"/></rom-file>
-	  <rom-file id="06654"><area-name id="234"/></rom-file>
-	  <rom-file id="06657"><area-name id="237"/></rom-file>
-	  <rom-file id="06656"><area-name id="236"/></rom-file>
-	</category>
-	<category><name><region-name id="002"/></name>
-	  <rom-file id="06662"><area-name id="242"/></rom-file>
-	  <rom-file id="06660"><area-name id="240"/></rom-file>
-	  <rom-file id="06659"><area-name id="239"/></rom-file>
-	  <rom-file id="06658"><area-name id="238"/></rom-file>
-	  <rom-file id="06661"><area-name id="241"/></rom-file>
-	</category>
-	<category><name><region-name id="003"/></name>
-	  <rom-file id="06665"><area-name id="245"/></rom-file>
-	  <rom-file id="06666"><area-name id="246"/></rom-file>
-	  <rom-file id="06663"><area-name id="243"/></rom-file>
-	  <rom-file id="06664"><area-name id="244"/></rom-file>
-	</category>
-	<category><name><region-name id="004"/></name>
-	  <rom-file id="06587"><area-name id="167"/></rom-file>
-	  <rom-file id="06521"><area-name id="101"/></rom-file>
-	  <rom-file id="06561"><area-name id="141"/></rom-file>
-	  <rom-file id="06560"><area-name id="140"/></rom-file>
-	  <rom-file id="06559"><area-name id="139"/></rom-file>
-	  <rom-file id="06610"><area-name id="190"/></rom-file>
-	  <rom-file id="06520"><area-name id="100"/></rom-file>
-	  <rom-file id="06562"><area-name id="142"/></rom-file>
-	</category>
-	<category><name><region-name id="005"/></name>
-	  <rom-file id="06616"><area-name id="196"/></rom-file>
-	  <rom-file id="06528"><area-name id="108"/></rom-file>
-	  <rom-file id="06522"><area-name id="102"/></rom-file>
-	  <rom-file id="06613"><area-name id="193"/></rom-file>
-	  <rom-file id="06668"><area-name id="248"/></rom-file>
-	  <rom-file id="06523"><area-name id="103"/></rom-file>
-	</category>
-	<category><name><region-name id="006"/></name>
-	  <rom-file id="06525"><area-name id="105"/></rom-file>
-	  <rom-file id="06422"><area-name id="002"/></rom-file>
-	  <rom-file id="06569"><area-name id="149"/></rom-file>
-	  <rom-file id="06524"><area-name id="104"/></rom-file>
-	  <rom-file id="06570"><area-name id="150"/></rom-file>
-	  <rom-file id="06421"><area-name id="001"/></rom-file>
-	  <rom-file id="06615"><area-name id="195"/></rom-file>
-	</category>
-	<category><name><region-name id="007"/></name>
-	  <rom-file id="06611"><area-name id="191"/></rom-file>
-	  <rom-file id="06593"><area-name id="173"/></rom-file>
-	  <rom-file id="06526"><area-name id="106"/></rom-file>
-	  <rom-file id="06563"><area-name id="143"/></rom-file>
-	  <rom-file id="06527"><area-name id="107"/></rom-file>
-	  <rom-file id="06564"><area-name id="144"/></rom-file>
-	  <rom-file id="06592"><area-name id="172"/></rom-file>
-	</category>
-	<category><name><region-name id="008"/></name>
-	  <rom-file id="06567"><area-name id="147"/></rom-file>
-	  <rom-file id="06617"><area-name id="197"/></rom-file>
-	  <rom-file id="06529"><area-name id="109"/></rom-file>
-	  <rom-file id="06568"><area-name id="148"/></rom-file>
-	  <rom-file id="06530"><area-name id="110"/></rom-file>
-	</category>
-	<category><name><region-name id="009"/></name>
-	  <rom-file id="06566"><area-name id="146"/></rom-file>
-	  <rom-file id="06536"><area-name id="116"/></rom-file>
-	  <rom-file id="06590"><area-name id="170"/></rom-file>
-	  <rom-file id="06565"><area-name id="145"/></rom-file>
-	  <rom-file id="06612"><area-name id="192"/></rom-file>
-	  <rom-file id="06614"><area-name id="194"/></rom-file>
-	  <rom-file id="06589"><area-name id="169"/></rom-file>
-	  <rom-file id="06535"><area-name id="115"/></rom-file>
-	</category>
-	<category><name><region-name id="010"/></name>
-	  <rom-file id="06424"><area-name id="004"/></rom-file>
-	  <rom-file id="06538"><area-name id="118"/></rom-file>
-	  <rom-file id="06633"><area-name id="213"/></rom-file>
-	  <rom-file id="06423"><area-name id="003"/></rom-file>
-	  <rom-file id="06618"><area-name id="198"/></rom-file>
-	  <rom-file id="06669"><area-name id="249"/></rom-file>
-	  <rom-file id="06537"><area-name id="117"/></rom-file>
-	</category>
-	<category><name><region-name id="011"/></name>
-	  <rom-file id="06572"><area-name id="152"/></rom-file>
-	  <rom-file id="06427"><area-name id="007"/></rom-file>
-	  <rom-file id="06428"><area-name id="008"/></rom-file>
-	  <rom-file id="06571"><area-name id="151"/></rom-file>
-	  <rom-file id="06620"><area-name id="200"/></rom-file>
-	  <rom-file id="06539"><area-name id="119"/></rom-file>
-	  <rom-file id="06540"><area-name id="120"/></rom-file>
-	</category>
-	<category><name><region-name id="012"/></name>
-	  <rom-file id="06531"><area-name id="111"/></rom-file>
-	  <rom-file id="06623"><area-name id="203"/></rom-file>
-	  <rom-file id="06624"><area-name id="204"/></rom-file>
-	  <rom-file id="06429"><area-name id="009"/></rom-file>
-	  <rom-file id="06586"><area-name id="166"/></rom-file>
-	  <rom-file id="06626"><area-name id="206"/></rom-file>
-	  <rom-file id="06430"><area-name id="010"/></rom-file>
-	</category>
-	<category><name><region-name id="013"/></name>
-	  <rom-file id="06426"><area-name id="006"/></rom-file>
-	  <rom-file id="06581"><area-name id="161"/></rom-file>
-	  <rom-file id="06582"><area-name id="162"/></rom-file>
-	  <rom-file id="06585"><area-name id="165"/></rom-file>
-	  <rom-file id="06425"><area-name id="005"/></rom-file>
-	  <rom-file id="06532"><area-name id="112"/></rom-file>
-	</category>
-	<category><name><region-name id="014"/></name>
-	  <rom-file id="06547"><area-name id="127"/></rom-file>
-	  <rom-file id="06604"><area-name id="184"/></rom-file>
-	  <rom-file id="06577"><area-name id="157"/></rom-file>
-	  <rom-file id="06551"><area-name id="131"/></rom-file>
-	  <rom-file id="06546"><area-name id="126"/></rom-file>
-	  <rom-file id="06599"><area-name id="179"/></rom-file>
-	  <rom-file id="06578"><area-name id="158"/></rom-file>
-	</category>
-      </category>
-      <category><name>&amp;<i18n-string id="FFXI2"/></name>
-	<category><name><region-name id="015"/></name>
-	  <rom-file id="06622"><area-name id="202"/></rom-file>
-	  <rom-file id="06574"><area-name id="154"/></rom-file>
-	  <rom-file id="06671"><area-name id="251"/></rom-file>
-	  <rom-file id="06542"><area-name id="122"/></rom-file>
-	  <rom-file id="06573"><area-name id="153"/></rom-file>
-	  <rom-file id="06541"><area-name id="121"/></rom-file>
-	</category>
-	<category><name><region-name id="016"/></name>
-	  <rom-file id="06588"><area-name id="168"/></rom-file>
-	  <rom-file id="06629"><area-name id="209"/></rom-file>
-	  <rom-file id="06534"><area-name id="114"/></rom-file>
-	  <rom-file id="06628"><area-name id="208"/></rom-file>
-	  <rom-file id="06667"><area-name id="247"/></rom-file>
-	  <rom-file id="06545"><area-name id="125"/></rom-file>
-	</category>
-	<category><name><region-name id="017"/></name>
-	  <rom-file id="06533"><area-name id="113"/></rom-file>
-	  <rom-file id="06621"><area-name id="201"/></rom-file>
-	  <rom-file id="06632"><area-name id="212"/></rom-file>
-	  <rom-file id="06594"><area-name id="174"/></rom-file>
-	  <rom-file id="06548"><area-name id="128"/></rom-file>
-	</category>
-	<category><name><region-name id="018"/></name>
-	  <rom-file id="06670"><area-name id="250"/></rom-file>
-	  <rom-file id="06672"><area-name id="252"/></rom-file>
-	  <rom-file id="06596"><area-name id="176"/></rom-file>
-	  <rom-file id="06543"><area-name id="123"/></rom-file>
-	</category>
-	<category><name><region-name id="019"/></name>
-	  <rom-file id="06627"><area-name id="207"/></rom-file>
-	  <rom-file id="06631"><area-name id="211"/></rom-file>
-	  <rom-file id="06580"><area-name id="160"/></rom-file>
-	  <rom-file id="06625"><area-name id="205"/></rom-file>
-	  <rom-file id="06583"><area-name id="163"/></rom-file>
-	  <rom-file id="06579"><area-name id="159"/></rom-file>
-	  <rom-file id="06544"><area-name id="124"/></rom-file>
-	</category>
-	<category><name><region-name id="020"/></name>
-	  <rom-file id="06600"><area-name id="180"/></rom-file>
-	  <rom-file id="06550"><area-name id="130"/></rom-file>
-	  <rom-file id="06601"><area-name id="181"/></rom-file>
-	  <rom-file id="06598"><area-name id="178"/></rom-file>
-	  <rom-file id="06597"><area-name id="177"/></rom-file>
-	</category>
-	<category><name><region-name id="021"/></name>
-	  <rom-file id="06606"><area-name id="186"/></rom-file>
-	  <rom-file id="06554"><area-name id="134"/></rom-file>
-	  <rom-file id="06460"><area-name id="040"/></rom-file>
-	  <rom-file id="06608"><area-name id="188"/></rom-file>
-	  <rom-file id="06461"><area-name id="041"/></rom-file>
-	  <rom-file id="06605"><area-name id="185"/></rom-file>
-	  <rom-file id="06462"><area-name id="042"/></rom-file>
-	  <rom-file id="06459"><area-name id="039"/></rom-file>
-	  <rom-file id="06607"><area-name id="187"/></rom-file>
-	  <rom-file id="06555"><area-name id="135"/></rom-file>
-	</category>
-      </category>
-      <category><name>&amp;<i18n-string id="FFXI3"/></name>
-	<category><name><region-name id="022"/></name>
-	  <rom-file id="06432"><area-name id="012"/></rom-file>
-	  <rom-file id="06433"><area-name id="013"/></rom-file>
-	  <rom-file id="06431"><area-name id="011"/></rom-file>
-	</category>
-	<category><name><region-name id="023"/></name>
-	  <rom-file id="06446"><area-name id="026"/></rom-file>
-	</category>
-	<category><name><region-name id="024"/></name>
-	  <rom-file id="06444"><area-name id="024"/></rom-file>
-	  <rom-file id="06445"><area-name id="025"/></rom-file>
-	  <rom-file id="06447"><area-name id="027"/></rom-file>
-	  <rom-file id="06448"><area-name id="028"/></rom-file>
-	  <rom-file id="06449"><area-name id="029"/></rom-file>
-	  <rom-file id="06450"><area-name id="030"/></rom-file>
-	  <rom-file id="06451"><area-name id="031"/></rom-file>
-	  <rom-file id="06452"><area-name id="032"/></rom-file>
-	</category>
-	<category><name><region-name id="025"/></name>
-	  <rom-file id="06434"><area-name id="014"/></rom-file>
-	  <rom-file id="06438"><area-name id="018"/></rom-file>
-	  <rom-file id="06436"><area-name id="016"/></rom-file>
-	  <rom-file id="06440"><area-name id="020"/></rom-file>
-	  <rom-file id="06442"><area-name id="022"/></rom-file>
-	  <rom-file id="06439"><area-name id="019"/></rom-file>
-	  <rom-file id="06437"><area-name id="017"/></rom-file>
-	  <rom-file id="06441"><area-name id="021"/></rom-file>
-	  <rom-file id="06443"><area-name id="023"/></rom-file>
-	</category>
-	<category><name><region-name id="026"/></name>
-	  <rom-file id="06453"><area-name id="033"/></rom-file>
-	  <rom-file id="06456"><area-name id="036"/></rom-file>
-	  <rom-file id="06454"><area-name id="034"/></rom-file>
-	  <rom-file id="06455"><area-name id="035"/></rom-file>
-	</category>
-	<category><name><region-name id="027"/></name>
-	  <rom-file id="06458"><area-name id="038"/></rom-file>
-	  <rom-file id="06457"><area-name id="037"/></rom-file>
-	</category>
-      </category>
-      <category><name>&amp;<i18n-string id="FFXI4"/></name>
-	<category><name><region-name id="028"/></name></category>
-	<category><name><region-name id="029"/></name>
-	  <rom-file id="06470"><area-name id="050"/></rom-file>
-	  <rom-file id="57945"><area-name id="050"/>-2</rom-file>
-	  <rom-file id="06468"><area-name id="048"/></rom-file>
-	  <rom-file id="06472"><area-name id="052"/></rom-file>
-	  <rom-file id="06490"><area-name id="070"/></rom-file>
-	  <rom-file id="06491"><area-name id="071"/></rom-file>
-	</category>
-	<category><name><region-name id="030"/></name>
-	  <rom-file id="06488"><area-name id="068"/></rom-file>
-	  <rom-file id="06487"><area-name id="067"/></rom-file>
-	  <rom-file id="06485"><area-name id="065"/></rom-file>
-	  <rom-file id="06486"><area-name id="066"/></rom-file>
-	  <rom-file id="06471"><area-name id="051"/></rom-file>
-	</category>
-	<category><name><region-name id="031"/></name>
-	  <rom-file id="06482"><area-name id="062"/></rom-file>
-	  <rom-file id="06483"><area-name id="063"/></rom-file>
-	  <rom-file id="06481"><area-name id="061"/></rom-file>
-	  <rom-file id="06484"><area-name id="064"/></rom-file>
-	</category>
-	<category><name><region-name id="032"/></name>
-	  <rom-file id="06474"><area-name id="054"/></rom-file>
-	  <rom-file id="06499"><area-name id="079"/></rom-file>
-	  <rom-file id="06498"><area-name id="078"/></rom-file>
-	  <rom-file id="06475"><area-name id="055"/></rom-file>
-	  <rom-file id="06489"><area-name id="069"/></rom-file>
-	  <rom-file id="06473"><area-name id="053"/></rom-file>
-	  <rom-file id="06476"><area-name id="056"/></rom-file>
-	  <rom-file id="06477"><area-name id="057"/></rom-file>
-	  <rom-file id="06480"><area-name id="060"/></rom-file>
-	</category>
-	<category><name><region-name id="033"/></name>
-	  <rom-file id="06492"><area-name id="072"/></rom-file>
-	  <rom-file id="06494"><area-name id="074"/></rom-file>
-	  <rom-file id="06495"><area-name id="075"/></rom-file>
-	  <rom-file id="06497"><area-name id="077"/></rom-file>
-	  <rom-file id="06496"><area-name id="076"/></rom-file>
-	  <rom-file id="06493"><area-name id="073"/></rom-file>
-	</category>
-      </category>
-      <category><name>&amp;<i18n-string id="FFXI5"/></name>
-	<category><name><region-name id="034"/></name>
-	  <rom-file id="06501"><area-name id="081"/></rom-file>
-	  <rom-file id="06506"><area-name id="086"/></rom-file>
-	  <rom-file id="06500"><area-name id="080"/></rom-file>
-	</category>
-	<category><name><region-name id="035"/></name>
-	  <rom-file id="06504"><area-name id="084"/></rom-file>
-	  <rom-file id="06502"><area-name id="082"/></rom-file>
-	  <rom-file id="06505"><area-name id="085"/></rom-file>
-	  <rom-file id="06595"><area-name id="175"/></rom-file>
-	</category>
-	<category><name><region-name id="036"/></name>
-	  <rom-file id="06507"><area-name id="087"/></rom-file>
-	  <rom-file id="06509"><area-name id="089"/></rom-file>
-	  <rom-file id="06508"><area-name id="088"/></rom-file>
-	  <rom-file id="06513"><area-name id="093"/></rom-file>
-	</category>
-	<category><name><region-name id="037"/></name>
-	  <rom-file id="06512"><area-name id="092"/></rom-file>
-	  <rom-file id="06591"><area-name id="171"/></rom-file>
-	  <rom-file id="06510"><area-name id="090"/></rom-file>
-	  <rom-file id="06511"><area-name id="091"/></rom-file>
-	  <rom-file id="06503"><area-name id="083"/></rom-file>
-	</category>
-	<category><name><region-name id="038"/></name>
-	  <rom-file id="06516"><area-name id="096"/></rom-file>
-	  <rom-file id="06549"><area-name id="129"/></rom-file>
-	  <rom-file id="06515"><area-name id="095"/></rom-file>
-	  <rom-file id="06514"><area-name id="094"/></rom-file>
-	</category>
-	<category><name><region-name id="039"/></name>
-	  <rom-file id="06519"><area-name id="099"/></rom-file>
-	  <rom-file id="06584"><area-name id="164"/></rom-file>
-	  <rom-file id="06517"><area-name id="097"/></rom-file>
-	  <rom-file id="06518"><area-name id="098"/></rom-file>
-	</category>
-	<category><name><region-name id="040"/></name>
-	  <rom-file id="06556"><area-name id="136"/></rom-file>
-	</category>
-	<category><name><region-name id="041"/></name>
-	  <rom-file id="06558"><area-name id="138"/></rom-file>
-	  <rom-file id="06575"><area-name id="155"/></rom-file>
-	  <rom-file id="06576"><area-name id="156"/></rom-file>
-	  <rom-file id="06557"><area-name id="137"/></rom-file>
-	</category>
-	<category><name><region-name id="042"/></name>
-	</category>
-	<category><name><region-name id="043"/></name>
-	</category>
-	<category><name><region-name id="044"/></name>
-	</category>
-	<category><name><region-name id="045"/></name>
-	</category>
-	<category><name><region-name id="047"/></name>
-		<rom-file id="06602"><area-name id="182"/></rom-file>
-		<rom-file id="06642"><area-name id="222"/></rom-file>
-	</category>
-      </category>
-      <category><name>&amp;<i18n-string id="FFXI9"/></name>
-	<category><name><region-name id="049"/></name>
-	  <rom-file id="85591"><area-name id="256"/></rom-file>
-	  <rom-file id="85592"><area-name id="257"/></rom-file>
-	  <rom-file id="85593"><area-name id="258"/></rom-file>
-	  <rom-file id="85594"><area-name id="259"/></rom-file>
-	  <rom-file id="85615"><area-name id="280"/></rom-file>
-	  <rom-file id="85619"><area-name id="284"/></rom-file>
-	</category>
-	<category><name><region-name id="050"/></name>
-	  <rom-file id="85595"><area-name id="260"/></rom-file>
-	  <rom-file id="85596"><area-name id="261"/></rom-file>
-	  <rom-file id="85597"><area-name id="262"/></rom-file>
-	  <rom-file id="85598"><area-name id="263"/></rom-file>
-	  <rom-file id="85599"><area-name id="264"/></rom-file>
-	  <rom-file id="85600"><area-name id="265"/></rom-file>
-	  <rom-file id="85601"><area-name id="266"/></rom-file>
-	  <rom-file id="85602"><area-name id="267"/></rom-file>
-	  <rom-file id="85603"><area-name id="268"/></rom-file>
-	  <rom-file id="85604"><area-name id="269"/></rom-file>
-	  <rom-file id="85605"><area-name id="270"/></rom-file>
-	  <rom-file id="85606"><area-name id="271"/></rom-file>
-	  <rom-file id="85607"><area-name id="272"/></rom-file>
-	  <rom-file id="85608"><area-name id="273"/></rom-file>
-    <rom-file id="85609"><area-name id="274"/></rom-file>
-	  <rom-file id="85610"><area-name id="275"/></rom-file>
-	  <rom-file id="85611"><area-name id="276"/></rom-file>
-	  <rom-file id="85612"><area-name id="277"/></rom-file>
-    
-	</category>
-      </category>
-      <category><name><i18n-string id="Menu:Abyssea"/></name>
-	<rom-file id="06635"><area-name id="215"/></rom-file>
-	<rom-file id="06435"><area-name id="015"/></rom-file>
-	<rom-file id="06552"><area-name id="132"/></rom-file>
-	<rom-file id="06636"><area-name id="216"/></rom-file>
-	<rom-file id="06465"><area-name id="045"/></rom-file>
-	<rom-file id="06637"><area-name id="217"/></rom-file>
-	<rom-file id="06673"><area-name id="253"/></rom-file>
-	<rom-file id="06674"><area-name id="254"/></rom-file>
-	<rom-file id="06675"><area-name id="255"/></rom-file>
-	<rom-file id="06638"><area-name id="218"/></rom-file>
-      </category>
-      <category><name><i18n-string id="Menu:Other"/></name>
-	<rom-file id="06644"><area-name id="224"/></rom-file>
-	<rom-file id="06646"><area-name id="226"/></rom-file>
-	<rom-file id="06643"><area-name id="223"/></rom-file>
-	<rom-file id="06645"><area-name id="225"/></rom-file>
-	<separator/>
-	<rom-file id="06641"><area-name id="221"/></rom-file>
-	<rom-file id="06648"><area-name id="228"/> <i18n-string id="Menu:WithPirates"/></rom-file>
-	<rom-file id="06640"><area-name id="220"/></rom-file>
-	<rom-file id="06647"><area-name id="227"/> <i18n-string id="Menu:WithPirates"/></rom-file>
-	<separator/>
-	<rom-file id="06466"><area-name id="046"/></rom-file>
-	<rom-file id="06467"><area-name id="047"/></rom-file>
-	<rom-file id="06478"><area-name id="058"/></rom-file>
-	<rom-file id="06479"><area-name id="059"/></rom-file>
-	<separator/>
-	<rom-file id="06463"><area-name id="043"/></rom-file>
-	<rom-file id="06464"><area-name id="044"/></rom-file>
-	<rom-file id="06603"><area-name id="183"/></rom-file>
-	<separator/>
-	<rom-file id="85619"><area-name id="285"/></rom-file>
-	<separator/>
-	<!-- NOTE: <area-name id="210"/> won't do because in the client this is blank,
-		but leaked official documentation names it "GM Home" -->
-	<rom-file id="06630">GM Home</rom-file>
-	<separator/>
-	<!-- These are not area-related -->
-	<rom-file id="07025"><i18n-string id="Menu:EmoteMessages"/></rom-file>
-	<rom-file id="07035"><i18n-string id="Menu:MonsterSkillNames"/></rom-file>
-	<rom-file id="07029"><i18n-string id="Menu:StatusNames"/></rom-file>
-	<rom-file id="07023"><i18n-string id="Menu:SystemMessages"/> (1)</rom-file>
-	<rom-file id="07031"><i18n-string id="Menu:SystemMessages"/> (2)</rom-file>
-	<rom-file id="07021"><i18n-string id="Menu:SystemMessages"/> (3)</rom-file>
-	<rom-file id="07027"><i18n-string id="Menu:SystemMessages"/> (4)</rom-file>
-      </category>
+    <category><name><i18n-string id="Menu:DialogTables"/></name>
+        <!-- English: 06420-06675 -->
+        <category><name><i18n-string id="Menu:English"/></name>
+            <category><name>&amp;<i18n-string id="FFXI1"/></name>
+                <category><name><region-name id="000"/></name>
+                    <rom-file id="06653"><area-name id="233"/></rom-file>
+                    <rom-file id="06651"><area-name id="231"/></rom-file>
+                    <rom-file id="06652"><area-name id="232"/></rom-file>
+                    <rom-file id="06650"><area-name id="230"/></rom-file>
+                </category>
+                <category><name><region-name id="001"/></name>
+                    <rom-file id="06655"><area-name id="235"/></rom-file>
+                    <rom-file id="06654"><area-name id="234"/></rom-file>
+                    <rom-file id="06657"><area-name id="237"/></rom-file>
+                    <rom-file id="06656"><area-name id="236"/></rom-file>
+                </category>
+                <category><name><region-name id="002"/></name>
+                    <rom-file id="06662"><area-name id="242"/></rom-file>
+                    <rom-file id="06660"><area-name id="240"/></rom-file>
+                    <rom-file id="06659"><area-name id="239"/></rom-file>
+                    <rom-file id="06658"><area-name id="238"/></rom-file>
+                    <rom-file id="06661"><area-name id="241"/></rom-file>
+                </category>
+                <category><name><region-name id="003"/></name>
+                    <rom-file id="06665"><area-name id="245"/></rom-file>
+                    <rom-file id="06666"><area-name id="246"/></rom-file>
+                    <rom-file id="06663"><area-name id="243"/></rom-file>
+                    <rom-file id="06664"><area-name id="244"/></rom-file>
+                </category>
+                <category><name><region-name id="004"/></name>
+                    <rom-file id="06587"><area-name id="167"/></rom-file>
+                    <rom-file id="06521"><area-name id="101"/></rom-file>
+                    <rom-file id="06561"><area-name id="141"/></rom-file>
+                    <rom-file id="06560"><area-name id="140"/></rom-file>
+                    <rom-file id="06559"><area-name id="139"/></rom-file>
+                    <rom-file id="06610"><area-name id="190"/></rom-file>
+                    <rom-file id="06520"><area-name id="100"/></rom-file>
+                    <rom-file id="06562"><area-name id="142"/></rom-file>
+                </category>
+                <category><name><region-name id="005"/></name>
+                    <rom-file id="06616"><area-name id="196"/></rom-file>
+                    <rom-file id="06528"><area-name id="108"/></rom-file>
+                    <rom-file id="06522"><area-name id="102"/></rom-file>
+                    <rom-file id="06613"><area-name id="193"/></rom-file>
+                    <rom-file id="06668"><area-name id="248"/></rom-file>
+                    <rom-file id="06523"><area-name id="103"/></rom-file>
+                </category>
+                <category><name><region-name id="006"/></name>
+                    <rom-file id="06525"><area-name id="105"/></rom-file>
+                    <rom-file id="06422"><area-name id="002"/></rom-file>
+                    <rom-file id="06569"><area-name id="149"/></rom-file>
+                    <rom-file id="06524"><area-name id="104"/></rom-file>
+                    <rom-file id="06570"><area-name id="150"/></rom-file>
+                    <rom-file id="06421"><area-name id="001"/></rom-file>
+                    <rom-file id="06615"><area-name id="195"/></rom-file>
+                </category>
+                <category><name><region-name id="007"/></name>
+                    <rom-file id="06611"><area-name id="191"/></rom-file>
+                    <rom-file id="06593"><area-name id="173"/></rom-file>
+                    <rom-file id="06526"><area-name id="106"/></rom-file>
+                    <rom-file id="06563"><area-name id="143"/></rom-file>
+                    <rom-file id="06527"><area-name id="107"/></rom-file>
+                    <rom-file id="06564"><area-name id="144"/></rom-file>
+                    <rom-file id="06592"><area-name id="172"/></rom-file>
+                </category>
+                <category><name><region-name id="008"/></name>
+                    <rom-file id="06567"><area-name id="147"/></rom-file>
+                    <rom-file id="06617"><area-name id="197"/></rom-file>
+                    <rom-file id="06529"><area-name id="109"/></rom-file>
+                    <rom-file id="06568"><area-name id="148"/></rom-file>
+                    <rom-file id="06530"><area-name id="110"/></rom-file>
+                </category>
+                <category><name><region-name id="009"/></name>
+                    <rom-file id="06566"><area-name id="146"/></rom-file>
+                    <rom-file id="06536"><area-name id="116"/></rom-file>
+                    <rom-file id="06590"><area-name id="170"/></rom-file>
+                    <rom-file id="06565"><area-name id="145"/></rom-file>
+                    <rom-file id="06612"><area-name id="192"/></rom-file>
+                    <rom-file id="06614"><area-name id="194"/></rom-file>
+                    <rom-file id="06589"><area-name id="169"/></rom-file>
+                    <rom-file id="06535"><area-name id="115"/></rom-file>
+                </category>
+                <category><name><region-name id="010"/></name>
+                    <rom-file id="06424"><area-name id="004"/></rom-file>
+                    <rom-file id="06538"><area-name id="118"/></rom-file>
+                    <rom-file id="06633"><area-name id="213"/></rom-file>
+                    <rom-file id="06423"><area-name id="003"/></rom-file>
+                    <rom-file id="06618"><area-name id="198"/></rom-file>
+                    <rom-file id="06669"><area-name id="249"/></rom-file>
+                    <rom-file id="06537"><area-name id="117"/></rom-file>
+                </category>
+                <category><name><region-name id="011"/></name>
+                    <rom-file id="06572"><area-name id="152"/></rom-file>
+                    <rom-file id="06427"><area-name id="007"/></rom-file>
+                    <rom-file id="06428"><area-name id="008"/></rom-file>
+                    <rom-file id="06571"><area-name id="151"/></rom-file>
+                    <rom-file id="06620"><area-name id="200"/></rom-file>
+                    <rom-file id="06539"><area-name id="119"/></rom-file>
+                    <rom-file id="06540"><area-name id="120"/></rom-file>
+                </category>
+                <category><name><region-name id="012"/></name>
+                    <rom-file id="06531"><area-name id="111"/></rom-file>
+                    <rom-file id="06623"><area-name id="203"/></rom-file>
+                    <rom-file id="06624"><area-name id="204"/></rom-file>
+                    <rom-file id="06429"><area-name id="009"/></rom-file>
+                    <rom-file id="06586"><area-name id="166"/></rom-file>
+                    <rom-file id="06626"><area-name id="206"/></rom-file>
+                    <rom-file id="06430"><area-name id="010"/></rom-file>
+                </category>
+                <category><name><region-name id="013"/></name>
+                    <rom-file id="06426"><area-name id="006"/></rom-file>
+                    <rom-file id="06581"><area-name id="161"/></rom-file>
+                    <rom-file id="06582"><area-name id="162"/></rom-file>
+                    <rom-file id="06585"><area-name id="165"/></rom-file>
+                    <rom-file id="06425"><area-name id="005"/></rom-file>
+                    <rom-file id="06532"><area-name id="112"/></rom-file>
+                </category>
+                <category><name><region-name id="014"/></name>
+                    <rom-file id="06547"><area-name id="127"/></rom-file>
+                    <rom-file id="06604"><area-name id="184"/></rom-file>
+                    <rom-file id="06577"><area-name id="157"/></rom-file>
+                    <rom-file id="06551"><area-name id="131"/></rom-file>
+                    <rom-file id="06546"><area-name id="126"/></rom-file>
+                    <rom-file id="06599"><area-name id="179"/></rom-file>
+                    <rom-file id="06578"><area-name id="158"/></rom-file>
+                </category>
+            </category>
+            <category><name>&amp;<i18n-string id="FFXI2"/></name>
+                <category><name><region-name id="015"/></name>
+                    <rom-file id="06622"><area-name id="202"/></rom-file>
+                    <rom-file id="06574"><area-name id="154"/></rom-file>
+                    <rom-file id="06671"><area-name id="251"/></rom-file>
+                    <rom-file id="06542"><area-name id="122"/></rom-file>
+                    <rom-file id="06573"><area-name id="153"/></rom-file>
+                    <rom-file id="06541"><area-name id="121"/></rom-file>
+                </category>
+                <category><name><region-name id="016"/></name>
+                    <rom-file id="06588"><area-name id="168"/></rom-file>
+                    <rom-file id="06629"><area-name id="209"/></rom-file>
+                    <rom-file id="06534"><area-name id="114"/></rom-file>
+                    <rom-file id="06628"><area-name id="208"/></rom-file>
+                    <rom-file id="06667"><area-name id="247"/></rom-file>
+                    <rom-file id="06545"><area-name id="125"/></rom-file>
+                </category>
+                <category><name><region-name id="017"/></name>
+                    <rom-file id="06533"><area-name id="113"/></rom-file>
+                    <rom-file id="06621"><area-name id="201"/></rom-file>
+                    <rom-file id="06632"><area-name id="212"/></rom-file>
+                    <rom-file id="06594"><area-name id="174"/></rom-file>
+                    <rom-file id="06548"><area-name id="128"/></rom-file>
+                </category>
+                <category><name><region-name id="018"/></name>
+                    <rom-file id="06670"><area-name id="250"/></rom-file>
+                    <rom-file id="06672"><area-name id="252"/></rom-file>
+                    <rom-file id="06596"><area-name id="176"/></rom-file>
+                    <rom-file id="06543"><area-name id="123"/></rom-file>
+                </category>
+                <category><name><region-name id="019"/></name>
+                    <rom-file id="06627"><area-name id="207"/></rom-file>
+                    <rom-file id="06631"><area-name id="211"/></rom-file>
+                    <rom-file id="06580"><area-name id="160"/></rom-file>
+                    <rom-file id="06625"><area-name id="205"/></rom-file>
+                    <rom-file id="06583"><area-name id="163"/></rom-file>
+                    <rom-file id="06579"><area-name id="159"/></rom-file>
+                    <rom-file id="06544"><area-name id="124"/></rom-file>
+                </category>
+                <category><name><region-name id="020"/></name>
+                    <rom-file id="06600"><area-name id="180"/></rom-file>
+                    <rom-file id="06550"><area-name id="130"/></rom-file>
+                    <rom-file id="06601"><area-name id="181"/></rom-file>
+                    <rom-file id="06598"><area-name id="178"/></rom-file>
+                    <rom-file id="06597"><area-name id="177"/></rom-file>
+                </category>
+                <category><name><region-name id="021"/></name>
+                    <rom-file id="06606"><area-name id="186"/></rom-file>
+                    <rom-file id="06554"><area-name id="134"/></rom-file>
+                    <rom-file id="06460"><area-name id="040"/></rom-file>
+                    <rom-file id="06608"><area-name id="188"/></rom-file>
+                    <rom-file id="06461"><area-name id="041"/></rom-file>
+                    <rom-file id="06605"><area-name id="185"/></rom-file>
+                    <rom-file id="06462"><area-name id="042"/></rom-file>
+                    <rom-file id="06459"><area-name id="039"/></rom-file>
+                    <rom-file id="06607"><area-name id="187"/></rom-file>
+                    <rom-file id="06555"><area-name id="135"/></rom-file>
+                </category>
+            </category>
+            <category><name>&amp;<i18n-string id="FFXI3"/></name>
+                <category><name><region-name id="022"/></name>
+                    <rom-file id="06432"><area-name id="012"/></rom-file>
+                    <rom-file id="06433"><area-name id="013"/></rom-file>
+                    <rom-file id="06431"><area-name id="011"/></rom-file>
+                </category>
+                <category><name><region-name id="023"/></name>
+                    <rom-file id="06446"><area-name id="026"/></rom-file>
+                </category>
+                <category><name><region-name id="024"/></name>
+                    <rom-file id="06444"><area-name id="024"/></rom-file>
+                    <rom-file id="06445"><area-name id="025"/></rom-file>
+                    <rom-file id="06447"><area-name id="027"/></rom-file>
+                    <rom-file id="06448"><area-name id="028"/></rom-file>
+                    <rom-file id="06449"><area-name id="029"/></rom-file>
+                    <rom-file id="06450"><area-name id="030"/></rom-file>
+                    <rom-file id="06451"><area-name id="031"/></rom-file>
+                    <rom-file id="06452"><area-name id="032"/></rom-file>
+                </category>
+                <category><name><region-name id="025"/></name>
+                    <rom-file id="06434"><area-name id="014"/></rom-file>
+                    <rom-file id="06438"><area-name id="018"/></rom-file>
+                    <rom-file id="06436"><area-name id="016"/></rom-file>
+                    <rom-file id="06440"><area-name id="020"/></rom-file>
+                    <rom-file id="06442"><area-name id="022"/></rom-file>
+                    <rom-file id="06439"><area-name id="019"/></rom-file>
+                    <rom-file id="06437"><area-name id="017"/></rom-file>
+                    <rom-file id="06441"><area-name id="021"/></rom-file>
+                    <rom-file id="06443"><area-name id="023"/></rom-file>
+                </category>
+                <category><name><region-name id="026"/></name>
+                    <rom-file id="06453"><area-name id="033"/></rom-file>
+                    <rom-file id="06456"><area-name id="036"/></rom-file>
+                    <rom-file id="06454"><area-name id="034"/></rom-file>
+                    <rom-file id="06455"><area-name id="035"/></rom-file>
+                </category>
+                <category><name><region-name id="027"/></name>
+                    <rom-file id="06458"><area-name id="038"/></rom-file>
+                    <rom-file id="06457"><area-name id="037"/></rom-file>
+                </category>
+            </category>
+            <category><name>&amp;<i18n-string id="FFXI4"/></name>
+                <category><name><region-name id="028"/></name></category>
+                <category><name><region-name id="029"/></name>
+                    <rom-file id="06470"><area-name id="050"/></rom-file>
+                    <rom-file id="57945"><area-name id="050"/>-2</rom-file>
+                    <rom-file id="06468"><area-name id="048"/></rom-file>
+                    <rom-file id="06472"><area-name id="052"/></rom-file>
+                    <rom-file id="06490"><area-name id="070"/></rom-file>
+                    <rom-file id="06491"><area-name id="071"/></rom-file>
+                </category>
+                <category><name><region-name id="030"/></name>
+                    <rom-file id="06488"><area-name id="068"/></rom-file>
+                    <rom-file id="06487"><area-name id="067"/></rom-file>
+                    <rom-file id="06485"><area-name id="065"/></rom-file>
+                    <rom-file id="06486"><area-name id="066"/></rom-file>
+                    <rom-file id="06471"><area-name id="051"/></rom-file>
+                </category>
+                <category><name><region-name id="031"/></name>
+                    <rom-file id="06482"><area-name id="062"/></rom-file>
+                    <rom-file id="06483"><area-name id="063"/></rom-file>
+                    <rom-file id="06481"><area-name id="061"/></rom-file>
+                    <rom-file id="06484"><area-name id="064"/></rom-file>
+                </category>
+                <category><name><region-name id="032"/></name>
+                    <rom-file id="06474"><area-name id="054"/></rom-file>
+                    <rom-file id="06499"><area-name id="079"/></rom-file>
+                    <rom-file id="06498"><area-name id="078"/></rom-file>
+                    <rom-file id="06475"><area-name id="055"/></rom-file>
+                    <rom-file id="06489"><area-name id="069"/></rom-file>
+                    <rom-file id="06473"><area-name id="053"/></rom-file>
+                    <rom-file id="06476"><area-name id="056"/></rom-file>
+                    <rom-file id="06477"><area-name id="057"/></rom-file>
+                    <rom-file id="06480"><area-name id="060"/></rom-file>
+                </category>
+                <category><name><region-name id="033"/></name>
+                    <rom-file id="06492"><area-name id="072"/></rom-file>
+                    <rom-file id="06494"><area-name id="074"/></rom-file>
+                    <rom-file id="06495"><area-name id="075"/></rom-file>
+                    <rom-file id="06497"><area-name id="077"/></rom-file>
+                    <rom-file id="06496"><area-name id="076"/></rom-file>
+                    <rom-file id="06493"><area-name id="073"/></rom-file>
+                </category>
+            </category>
+            <category><name>&amp;<i18n-string id="FFXI5"/></name>
+                <category><name><region-name id="034"/></name>
+                    <rom-file id="06501"><area-name id="081"/></rom-file>
+                    <rom-file id="06506"><area-name id="086"/></rom-file>
+                    <rom-file id="06500"><area-name id="080"/></rom-file>
+                </category>
+                <category><name><region-name id="035"/></name>
+                    <rom-file id="06504"><area-name id="084"/></rom-file>
+                    <rom-file id="06502"><area-name id="082"/></rom-file>
+                    <rom-file id="06505"><area-name id="085"/></rom-file>
+                    <rom-file id="06595"><area-name id="175"/></rom-file>
+                </category>
+                <category><name><region-name id="036"/></name>
+                    <rom-file id="06507"><area-name id="087"/></rom-file>
+                    <rom-file id="06509"><area-name id="089"/></rom-file>
+                    <rom-file id="06508"><area-name id="088"/></rom-file>
+                    <rom-file id="06513"><area-name id="093"/></rom-file>
+                </category>
+                <category><name><region-name id="037"/></name>
+                    <rom-file id="06512"><area-name id="092"/></rom-file>
+                    <rom-file id="06591"><area-name id="171"/></rom-file>
+                    <rom-file id="06510"><area-name id="090"/></rom-file>
+                    <rom-file id="06511"><area-name id="091"/></rom-file>
+                    <rom-file id="06503"><area-name id="083"/></rom-file>
+                </category>
+                <category><name><region-name id="038"/></name>
+                    <rom-file id="06516"><area-name id="096"/></rom-file>
+                    <rom-file id="06549"><area-name id="129"/></rom-file>
+                    <rom-file id="06515"><area-name id="095"/></rom-file>
+                    <rom-file id="06514"><area-name id="094"/></rom-file>
+                </category>
+                <category><name><region-name id="039"/></name>
+                    <rom-file id="06519"><area-name id="099"/></rom-file>
+                    <rom-file id="06584"><area-name id="164"/></rom-file>
+                    <rom-file id="06517"><area-name id="097"/></rom-file>
+                    <rom-file id="06518"><area-name id="098"/></rom-file>
+                </category>
+                <category><name><region-name id="040"/></name>
+                    <rom-file id="06556"><area-name id="136"/></rom-file>
+                </category>
+                <category><name><region-name id="041"/></name>
+                    <rom-file id="06558"><area-name id="138"/></rom-file>
+                    <rom-file id="06575"><area-name id="155"/></rom-file>
+                    <rom-file id="06576"><area-name id="156"/></rom-file>
+                    <rom-file id="06557"><area-name id="137"/></rom-file>
+                </category>
+                <category><name><region-name id="042"/></name>
+                </category>
+                <category><name><region-name id="043"/></name>
+                </category>
+                <category><name><region-name id="044"/></name>
+                </category>
+                <category><name><region-name id="045"/></name>
+                </category>
+                <category><name><region-name id="047"/></name>
+                    <rom-file id="06602"><area-name id="182"/></rom-file>
+                    <rom-file id="06642"><area-name id="222"/></rom-file>
+                </category>
+            </category>
+            <category><name>&amp;<i18n-string id="FFXI9"/></name>
+                <category><name><region-name id="049"/></name>
+                    <rom-file id="85591"><area-name id="256"/></rom-file>
+                    <rom-file id="85592"><area-name id="257"/></rom-file>
+                    <rom-file id="85593"><area-name id="258"/></rom-file>
+                    <rom-file id="85594"><area-name id="259"/></rom-file>
+                    <rom-file id="85615"><area-name id="280"/></rom-file>
+                    <rom-file id="85619"><area-name id="284"/></rom-file>
+                </category>
+                <category><name><region-name id="050"/></name>
+                    <rom-file id="85595"><area-name id="260"/></rom-file>
+                    <rom-file id="85596"><area-name id="261"/></rom-file>
+                    <rom-file id="85597"><area-name id="262"/></rom-file>
+                    <rom-file id="85598"><area-name id="263"/></rom-file>
+                    <rom-file id="85599"><area-name id="264"/></rom-file>
+                    <rom-file id="85600"><area-name id="265"/></rom-file>
+                    <rom-file id="85601"><area-name id="266"/></rom-file>
+                    <rom-file id="85602"><area-name id="267"/></rom-file>
+                    <rom-file id="85603"><area-name id="268"/></rom-file>
+                    <rom-file id="85604"><area-name id="269"/></rom-file>
+                    <rom-file id="85605"><area-name id="270"/></rom-file>
+                    <rom-file id="85606"><area-name id="271"/></rom-file>
+                    <rom-file id="85607"><area-name id="272"/></rom-file>
+                    <rom-file id="85608"><area-name id="273"/></rom-file>
+                    <rom-file id="85609"><area-name id="274"/></rom-file>
+                    <rom-file id="85610"><area-name id="275"/></rom-file>
+                    <rom-file id="85611"><area-name id="276"/></rom-file>
+                    <rom-file id="85612"><area-name id="277"/></rom-file>
+
+                </category>
+            </category>
+            <category><name><i18n-string id="Menu:Abyssea"/></name>
+                <rom-file id="06635"><area-name id="215"/></rom-file>
+                <rom-file id="06435"><area-name id="015"/></rom-file>
+                <rom-file id="06552"><area-name id="132"/></rom-file>
+                <rom-file id="06636"><area-name id="216"/></rom-file>
+                <rom-file id="06465"><area-name id="045"/></rom-file>
+                <rom-file id="06637"><area-name id="217"/></rom-file>
+                <rom-file id="06673"><area-name id="253"/></rom-file>
+                <rom-file id="06674"><area-name id="254"/></rom-file>
+                <rom-file id="06675"><area-name id="255"/></rom-file>
+                <rom-file id="06638"><area-name id="218"/></rom-file>
+            </category>
+            <category><name><i18n-string id="Rhapsodies of Vana'diel"/></name>
+            <!-- NOTE: For some reason "Menu:" kept showing up in the menu..Even though existing entries were formatted that way.. -->
+                <rom-file id="85623"><area-name id="288"/></rom-file>
+                <rom-file id="85624"><area-name id="289"/></rom-file>
+            </category>
+            <category><name><i18n-string id="Menu:Other"/></name>
+                <rom-file id="06644"><area-name id="224"/></rom-file>
+                <rom-file id="06646"><area-name id="226"/></rom-file>
+                <rom-file id="06643"><area-name id="223"/></rom-file>
+                <rom-file id="06645"><area-name id="225"/></rom-file>
+                <separator/>
+                <rom-file id="06641"><area-name id="221"/></rom-file>
+                <rom-file id="06648"><area-name id="228"/> <i18n-string id="Menu:WithPirates"/></rom-file>
+                <rom-file id="06640"><area-name id="220"/></rom-file>
+                <rom-file id="06647"><area-name id="227"/> <i18n-string id="Menu:WithPirates"/></rom-file>
+                <separator/>
+                <rom-file id="06466"><area-name id="046"/></rom-file>
+                <rom-file id="06467"><area-name id="047"/></rom-file>
+                <rom-file id="06478"><area-name id="058"/></rom-file>
+                <rom-file id="06479"><area-name id="059"/></rom-file>
+                <separator/>
+                <rom-file id="06463"><area-name id="043"/></rom-file>
+                <rom-file id="06464"><area-name id="044"/></rom-file>
+                <rom-file id="06603"><area-name id="183"/></rom-file>
+                <separator/>
+                <rom-file id="85619"><area-name id="285"/></rom-file>
+                <separator/>
+                <!-- NOTE: <area-name id="210"/> won't do because in the client this is blank, but leaked official documentation names it "GM Home" -->
+                <rom-file id="06630">GM Home</rom-file>
+                <separator/>
+                <!-- These are not area-related -->
+                <rom-file id="07025"><i18n-string id="Menu:EmoteMessages"/></rom-file>
+                <rom-file id="07035"><i18n-string id="Menu:MonsterSkillNames"/></rom-file>
+                <rom-file id="07029"><i18n-string id="Menu:StatusNames"/></rom-file>
+                <rom-file id="07023"><i18n-string id="Menu:SystemMessages"/> (1)</rom-file>
+                <rom-file id="07031"><i18n-string id="Menu:SystemMessages"/> (2)</rom-file>
+                <rom-file id="07021"><i18n-string id="Menu:SystemMessages"/> (3)</rom-file>
+                <rom-file id="07027"><i18n-string id="Menu:SystemMessages"/> (4)</rom-file>
+            </category>
+        </category>
+        <!-- French: 56285-56540 -->
+        <category><name><i18n-string id="Menu:French"/></name>
+            <category><name>&amp;<i18n-string id="FFXI1"/></name>
+                <category><name><region-name id="000"/></name>
+                    <rom-file id="56518"><area-name id="233"/></rom-file>
+                    <rom-file id="56516"><area-name id="231"/></rom-file>
+                    <rom-file id="56517"><area-name id="232"/></rom-file>
+                    <rom-file id="56515"><area-name id="230"/></rom-file>
+                </category>
+                <category><name><region-name id="001"/></name>
+                    <rom-file id="56520"><area-name id="235"/></rom-file>
+                    <rom-file id="56519"><area-name id="234"/></rom-file>
+                    <rom-file id="56522"><area-name id="237"/></rom-file>
+                    <rom-file id="56521"><area-name id="236"/></rom-file>
+                </category>
+                <category><name><region-name id="002"/></name>
+                    <rom-file id="56527"><area-name id="242"/></rom-file>
+                    <rom-file id="56525"><area-name id="240"/></rom-file>
+                    <rom-file id="56524"><area-name id="239"/></rom-file>
+                    <rom-file id="56523"><area-name id="238"/></rom-file>
+                    <rom-file id="56526"><area-name id="241"/></rom-file>
+                </category>
+                <category><name><region-name id="003"/></name>
+                    <rom-file id="56530"><area-name id="245"/></rom-file>
+                    <rom-file id="56531"><area-name id="246"/></rom-file>
+                    <rom-file id="56528"><area-name id="243"/></rom-file>
+                    <rom-file id="56529"><area-name id="244"/></rom-file>
+                </category>
+                <category><name><region-name id="004"/></name>
+                    <rom-file id="56452"><area-name id="167"/></rom-file>
+                    <rom-file id="56386"><area-name id="101"/></rom-file>
+                    <rom-file id="56426"><area-name id="141"/></rom-file>
+                    <rom-file id="56425"><area-name id="140"/></rom-file>
+                    <rom-file id="56424"><area-name id="139"/></rom-file>
+                    <rom-file id="56475"><area-name id="190"/></rom-file>
+                    <rom-file id="56385"><area-name id="100"/></rom-file>
+                    <rom-file id="56427"><area-name id="142"/></rom-file>
+                </category>
+                <category><name><region-name id="005"/></name>
+                    <rom-file id="56481"><area-name id="196"/></rom-file>
+                    <rom-file id="56393"><area-name id="108"/></rom-file>
+                    <rom-file id="56387"><area-name id="102"/></rom-file>
+                    <rom-file id="56478"><area-name id="193"/></rom-file>
+                    <rom-file id="56533"><area-name id="248"/></rom-file>
+                    <rom-file id="56388"><area-name id="103"/></rom-file>
+                </category>
+                <category><name><region-name id="006"/></name>
+                    <rom-file id="56390"><area-name id="105"/></rom-file>
+                    <rom-file id="56287"><area-name id="002"/></rom-file>
+                    <rom-file id="56434"><area-name id="149"/></rom-file>
+                    <rom-file id="56389"><area-name id="104"/></rom-file>
+                    <rom-file id="56435"><area-name id="150"/></rom-file>
+                    <rom-file id="56286"><area-name id="001"/></rom-file>
+                    <rom-file id="56480"><area-name id="195"/></rom-file>
+                </category>
+                <category><name><region-name id="007"/></name>
+                    <rom-file id="56476"><area-name id="191"/></rom-file>
+                    <rom-file id="56458"><area-name id="173"/></rom-file>
+                    <rom-file id="56391"><area-name id="106"/></rom-file>
+                    <rom-file id="56428"><area-name id="143"/></rom-file>
+                    <rom-file id="56392"><area-name id="107"/></rom-file>
+                    <rom-file id="56429"><area-name id="144"/></rom-file>
+                    <rom-file id="56457"><area-name id="172"/></rom-file>
+                </category>
+                <category><name><region-name id="008"/></name>
+                    <rom-file id="56432"><area-name id="147"/></rom-file>
+                    <rom-file id="56482"><area-name id="197"/></rom-file>
+                    <rom-file id="56394"><area-name id="109"/></rom-file>
+                    <rom-file id="56433"><area-name id="148"/></rom-file>
+                    <rom-file id="56395"><area-name id="110"/></rom-file>
+                </category>
+                <category><name><region-name id="009"/></name>
+                    <rom-file id="56431"><area-name id="146"/></rom-file>
+                    <rom-file id="56401"><area-name id="116"/></rom-file>
+                    <rom-file id="56455"><area-name id="170"/></rom-file>
+                    <rom-file id="56430"><area-name id="145"/></rom-file>
+                    <rom-file id="56477"><area-name id="192"/></rom-file>
+                    <rom-file id="56479"><area-name id="194"/></rom-file>
+                    <rom-file id="56454"><area-name id="169"/></rom-file>
+                    <rom-file id="56400"><area-name id="115"/></rom-file>
+                </category>
+                <category><name><region-name id="010"/></name>
+                    <rom-file id="56289"><area-name id="004"/></rom-file>
+                    <rom-file id="56403"><area-name id="118"/></rom-file>
+                    <rom-file id="56498"><area-name id="213"/></rom-file>
+                    <rom-file id="56288"><area-name id="003"/></rom-file>
+                    <rom-file id="56483"><area-name id="198"/></rom-file>
+                    <rom-file id="56534"><area-name id="249"/></rom-file>
+                    <rom-file id="56402"><area-name id="117"/></rom-file>
+                </category>
+                <category><name><region-name id="011"/></name>
+                    <rom-file id="56437"><area-name id="152"/></rom-file>
+                    <rom-file id="56292"><area-name id="007"/></rom-file>
+                    <rom-file id="56293"><area-name id="008"/></rom-file>
+                    <rom-file id="56436"><area-name id="151"/></rom-file>
+                    <rom-file id="56485"><area-name id="200"/></rom-file>
+                    <rom-file id="56404"><area-name id="119"/></rom-file>
+                    <rom-file id="56405"><area-name id="120"/></rom-file>
+                </category>
+                <category><name><region-name id="012"/></name>
+                    <rom-file id="56396"><area-name id="111"/></rom-file>
+                    <rom-file id="56488"><area-name id="203"/></rom-file>
+                    <rom-file id="56489"><area-name id="204"/></rom-file>
+                    <rom-file id="56294"><area-name id="009"/></rom-file>
+                    <rom-file id="56491"><area-name id="206"/></rom-file>
+                    <rom-file id="56451"><area-name id="166"/></rom-file>
+                    <rom-file id="56295"><area-name id="010"/></rom-file>
+                </category>
+                <category><name><region-name id="013"/></name>
+                    <rom-file id="56291"><area-name id="006"/></rom-file>
+                    <rom-file id="56446"><area-name id="161"/></rom-file>
+                    <rom-file id="56447"><area-name id="162"/></rom-file>
+                    <rom-file id="56450"><area-name id="165"/></rom-file>
+                    <rom-file id="56290"><area-name id="005"/></rom-file>
+                    <rom-file id="56397"><area-name id="112"/></rom-file>
+                </category>
+                <category><name><region-name id="014"/></name>
+                    <rom-file id="56412"><area-name id="127"/></rom-file>
+                    <rom-file id="56469"><area-name id="184"/></rom-file>
+                    <rom-file id="56442"><area-name id="157"/></rom-file>
+                    <rom-file id="56416"><area-name id="131"/></rom-file>
+                    <rom-file id="56411"><area-name id="126"/></rom-file>
+                    <rom-file id="56464"><area-name id="179"/></rom-file>
+                    <rom-file id="56443"><area-name id="158"/></rom-file>
+                </category>
+            </category>
+            <category><name>&amp;<i18n-string id="FFXI2"/></name>
+                <category><name><region-name id="015"/></name>
+                    <rom-file id="56487"><area-name id="202"/></rom-file>
+                    <rom-file id="56439"><area-name id="154"/></rom-file>
+                    <rom-file id="56536"><area-name id="251"/></rom-file>
+                    <rom-file id="56407"><area-name id="122"/></rom-file>
+                    <rom-file id="56438"><area-name id="153"/></rom-file>
+                    <rom-file id="56406"><area-name id="121"/></rom-file>
+                </category>
+                <category><name><region-name id="016"/></name>
+                    <rom-file id="56453"><area-name id="168"/></rom-file>
+                    <rom-file id="56494"><area-name id="209"/></rom-file>
+                    <rom-file id="56399"><area-name id="114"/></rom-file>
+                    <rom-file id="56493"><area-name id="208"/></rom-file>
+                    <rom-file id="56532"><area-name id="247"/></rom-file>
+                    <rom-file id="56410"><area-name id="125"/></rom-file>
+                </category>
+                <category><name><region-name id="017"/></name>
+                    <rom-file id="56398"><area-name id="113"/></rom-file>
+                    <rom-file id="56486"><area-name id="201"/></rom-file>
+                    <rom-file id="56497"><area-name id="212"/></rom-file>
+                    <rom-file id="56459"><area-name id="174"/></rom-file>
+                    <rom-file id="56413"><area-name id="128"/></rom-file>
+                </category>
+                <category><name><region-name id="018"/></name>
+                    <rom-file id="56535"><area-name id="250"/></rom-file>
+                    <rom-file id="56537"><area-name id="252"/></rom-file>
+                    <rom-file id="56461"><area-name id="176"/></rom-file>
+                    <rom-file id="56408"><area-name id="123"/></rom-file>
+                </category>
+                <category><name><region-name id="019"/></name>
+                    <rom-file id="56492"><area-name id="207"/></rom-file>
+                    <rom-file id="56496"><area-name id="211"/></rom-file>
+                    <rom-file id="56445"><area-name id="160"/></rom-file>
+                    <rom-file id="56490"><area-name id="205"/></rom-file>
+                    <rom-file id="56448"><area-name id="163"/></rom-file>
+                    <rom-file id="56444"><area-name id="159"/></rom-file>
+                    <rom-file id="56409"><area-name id="124"/></rom-file>
+                </category>
+                <category><name><region-name id="020"/></name>
+                    <rom-file id="56465"><area-name id="180"/></rom-file>
+                    <rom-file id="56415"><area-name id="130"/></rom-file>
+                    <rom-file id="56466"><area-name id="181"/></rom-file>
+                    <rom-file id="56463"><area-name id="178"/></rom-file>
+                    <rom-file id="56462"><area-name id="177"/></rom-file>
+                </category>
+                <category><name><region-name id="021"/></name>
+                    <rom-file id="56419"><area-name id="134"/></rom-file>
+                    <rom-file id="56420"><area-name id="135"/></rom-file>
+                    <rom-file id="56325"><area-name id="040"/></rom-file>
+                    <rom-file id="56470"><area-name id="185"/></rom-file>
+                    <rom-file id="56326"><area-name id="041"/></rom-file>
+                    <rom-file id="56471"><area-name id="186"/></rom-file>
+                    <rom-file id="56327"><area-name id="042"/></rom-file>
+                    <rom-file id="56324"><area-name id="039"/></rom-file>
+                    <rom-file id="56472"><area-name id="187"/></rom-file>
+                    <rom-file id="56473"><area-name id="188"/></rom-file>
+                </category>
+            </category>
+            <category><name>&amp;<i18n-string id="FFXI3"/></name>
+                <category><name><region-name id="022"/></name>
+                    <rom-file id="56297"><area-name id="012"/></rom-file>
+                    <rom-file id="56298"><area-name id="013"/></rom-file>
+                    <rom-file id="56296"><area-name id="011"/></rom-file>
+                </category>
+                <category><name><region-name id="023"/></name>
+                    <rom-file id="56311"><area-name id="026"/></rom-file>
+                </category>
+                <category><name><region-name id="024"/></name>
+                    <rom-file id="56309"><area-name id="024"/></rom-file>
+                    <rom-file id="56310"><area-name id="025"/></rom-file>
+                    <rom-file id="56312"><area-name id="027"/></rom-file>
+                    <rom-file id="56313"><area-name id="028"/></rom-file>
+                    <rom-file id="56314"><area-name id="029"/></rom-file>
+                    <rom-file id="56315"><area-name id="030"/></rom-file>
+                    <rom-file id="56316"><area-name id="031"/></rom-file>
+                    <rom-file id="56317"><area-name id="032"/></rom-file>
+                </category>
+                <category><name><region-name id="025"/></name>
+                    <rom-file id="56299"><area-name id="014"/></rom-file>
+                    <rom-file id="56303"><area-name id="018"/></rom-file>
+                    <rom-file id="56301"><area-name id="016"/></rom-file>
+                    <rom-file id="56305"><area-name id="020"/></rom-file>
+                    <rom-file id="56307"><area-name id="022"/></rom-file>
+                    <rom-file id="56304"><area-name id="019"/></rom-file>
+                    <rom-file id="56302"><area-name id="017"/></rom-file>
+                    <rom-file id="56306"><area-name id="021"/></rom-file>
+                    <rom-file id="56308"><area-name id="023"/></rom-file>
+                </category>
+                <category><name><region-name id="026"/></name>
+                    <rom-file id="56318"><area-name id="033"/></rom-file>
+                    <rom-file id="56321"><area-name id="036"/></rom-file>
+                    <rom-file id="56319"><area-name id="034"/></rom-file>
+                    <rom-file id="56320"><area-name id="035"/></rom-file>
+                </category>
+                <category><name><region-name id="027"/></name>
+                    <rom-file id="56323"><area-name id="038"/></rom-file>
+                    <rom-file id="56322"><area-name id="037"/></rom-file>
+                </category>
+            </category>
+            <category><name>&amp;<i18n-string id="FFXI4"/></name>
+                <category><name><region-name id="028"/></name></category>
+                <category><name><region-name id="029"/></name>
+                    <rom-file id="56335"><area-name id="050"/></rom-file>
+                    <rom-file id="58009"><area-name id="050"/>-2</rom-file>
+                    <rom-file id="56333"><area-name id="048"/></rom-file>
+                    <rom-file id="56337"><area-name id="052"/></rom-file>
+                    <rom-file id="56355"><area-name id="070"/></rom-file>
+                    <rom-file id="56356"><area-name id="071"/></rom-file>
+                </category>
+                <category><name><region-name id="030"/></name>
+                    <rom-file id="56353"><area-name id="068"/></rom-file>
+                    <rom-file id="56352"><area-name id="067"/></rom-file>
+                    <rom-file id="56350"><area-name id="065"/></rom-file>
+                    <rom-file id="56351"><area-name id="066"/></rom-file>
+                    <rom-file id="56336"><area-name id="051"/></rom-file>
+                </category>
+                <category><name><region-name id="031"/></name>
+                    <rom-file id="56347"><area-name id="062"/></rom-file>
+                    <rom-file id="56348"><area-name id="063"/></rom-file>
+                    <rom-file id="56346"><area-name id="061"/></rom-file>
+                    <rom-file id="56349"><area-name id="064"/></rom-file>
+                </category>
+                <category><name><region-name id="032"/></name>
+                    <rom-file id="56339"><area-name id="054"/></rom-file>
+                    <rom-file id="56364"><area-name id="079"/></rom-file>
+                    <rom-file id="56363"><area-name id="078"/></rom-file>
+                    <rom-file id="56340"><area-name id="055"/></rom-file>
+                    <rom-file id="56354"><area-name id="069"/></rom-file>
+                    <rom-file id="56338"><area-name id="053"/></rom-file>
+                    <rom-file id="56341"><area-name id="056"/></rom-file>
+                    <rom-file id="56342"><area-name id="057"/></rom-file>
+                    <rom-file id="56345"><area-name id="060"/></rom-file>
+                </category>
+                <category><name><region-name id="033"/></name>
+                    <rom-file id="56357"><area-name id="072"/></rom-file>
+                    <rom-file id="56359"><area-name id="074"/></rom-file>
+                    <rom-file id="56360"><area-name id="075"/></rom-file>
+                    <rom-file id="56362"><area-name id="077"/></rom-file>
+                    <rom-file id="56361"><area-name id="076"/></rom-file>
+                    <rom-file id="56358"><area-name id="073"/></rom-file>
+                </category>
+            </category>
+            <category><name>&amp;<i18n-string id="FFXI5"/></name>
+                <category><name><region-name id="034"/></name>
+                    <rom-file id="56366"><area-name id="081"/></rom-file>
+                    <rom-file id="56371"><area-name id="086"/></rom-file>
+                    <rom-file id="56365"><area-name id="080"/></rom-file>
+                </category>
+                <category><name><region-name id="035"/></name>
+                    <rom-file id="56369"><area-name id="084"/></rom-file>
+                    <rom-file id="56367"><area-name id="082"/></rom-file>
+                    <rom-file id="56370"><area-name id="085"/></rom-file>
+                    <rom-file id="56460"><area-name id="175"/></rom-file>
+                </category>
+                <category><name><region-name id="036"/></name>
+                    <rom-file id="56372"><area-name id="087"/></rom-file>
+                    <rom-file id="56374"><area-name id="089"/></rom-file>
+                    <rom-file id="56373"><area-name id="088"/></rom-file>
+                    <rom-file id="56378"><area-name id="093"/></rom-file>
+                </category>
+                <category><name><region-name id="037"/></name>
+                    <rom-file id="56377"><area-name id="092"/></rom-file>
+                    <rom-file id="56466"><area-name id="171"/></rom-file>
+                    <rom-file id="56375"><area-name id="090"/></rom-file>
+                    <rom-file id="56376"><area-name id="091"/></rom-file>
+                    <rom-file id="56368"><area-name id="083"/></rom-file>
+                </category>
+                <category><name><region-name id="038"/></name>
+                    <rom-file id="56381"><area-name id="096"/></rom-file>
+                    <rom-file id="56414"><area-name id="129"/></rom-file>
+                    <rom-file id="56380"><area-name id="095"/></rom-file>
+                    <rom-file id="56379"><area-name id="094"/></rom-file>
+                </category>
+                <category><name><region-name id="039"/></name>
+                    <rom-file id="56384"><area-name id="099"/></rom-file>
+                    <rom-file id="56449"><area-name id="164"/></rom-file>
+                    <rom-file id="56382"><area-name id="097"/></rom-file>
+                    <rom-file id="56383"><area-name id="098"/></rom-file>
+                </category>
+                <category><name><region-name id="040"/></name>
+                    <rom-file id="56421"><area-name id="136"/></rom-file>
+                </category>
+                <category><name><region-name id="041"/></name>
+                    <rom-file id="56423"><area-name id="138"/></rom-file>
+                    <rom-file id="56440"><area-name id="155"/></rom-file>
+                    <rom-file id="56441"><area-name id="156"/></rom-file>
+                    <rom-file id="56422"><area-name id="137"/></rom-file>
+                </category>
+                <category><name><region-name id="042"/></name>
+                </category>
+                <category><name><region-name id="043"/></name>
+                </category>
+                <category><name><region-name id="044"/></name>
+                </category>
+                <category><name><region-name id="045"/></name>
+                </category>
+                <category><name><region-name id="047"/></name>
+                    <rom-file id="56467"><area-name id="182"/></rom-file>
+                    <rom-file id="56507"><area-name id="222"/></rom-file>
+                </category>
+            </category>
+            <category><name><i18n-string id="Menu:Abyssea"/></name>
+                <rom-file id="56500"><area-name id="215"/></rom-file>
+                <rom-file id="56300"><area-name id="015"/></rom-file>
+                <rom-file id="56417"><area-name id="132"/></rom-file>
+                <rom-file id="56501"><area-name id="216"/></rom-file>
+                <rom-file id="56330"><area-name id="045"/></rom-file>
+                <rom-file id="56502"><area-name id="217"/></rom-file>
+                <rom-file id="56503"><area-name id="218"/></rom-file>
+                <rom-file id="56528"><area-name id="253"/></rom-file>
+                <rom-file id="56529"><area-name id="254"/></rom-file>
+                <rom-file id="56530"><area-name id="255"/></rom-file>
+            </category>
+            <category><name><i18n-string id="Menu:Other"/></name>
+                <rom-file id="56509"><area-name id="224"/></rom-file>
+                <rom-file id="56511"><area-name id="226"/></rom-file>
+                <rom-file id="56508"><area-name id="223"/></rom-file>
+                <rom-file id="56510"><area-name id="225"/></rom-file>
+                <separator/>
+                <rom-file id="56506"><area-name id="221"/></rom-file>
+                <rom-file id="56513"><area-name id="228"/> <i18n-string id="Menu:WithPirates"/></rom-file>
+                <rom-file id="56505"><area-name id="220"/></rom-file>
+                <rom-file id="56512"><area-name id="227"/> <i18n-string id="Menu:WithPirates"/></rom-file>
+                <separator/>
+                <rom-file id="56331"><area-name id="046"/></rom-file>
+                <rom-file id="56332"><area-name id="047"/></rom-file>
+                <rom-file id="56343"><area-name id="058"/></rom-file>
+                <rom-file id="56344"><area-name id="059"/></rom-file>
+                <separator/>
+                <rom-file id="56328"><area-name id="043"/></rom-file>
+                <rom-file id="56329"><area-name id="044"/></rom-file>
+                <rom-file id="56468"><area-name id="183"/></rom-file>
+                <separator/>
+                <rom-file id="56271"><i18n-string id="Menu:MonsterSkillNames"/></rom-file>
+            </category>
+        </category>
+        <!-- German: 55865-56120 -->
+        <category><name><i18n-string id="Menu:German"/></name>
+            <category><name>&amp;<i18n-string id="FFXI1"/></name>
+                <category><name><region-name id="000"/></name>
+                    <rom-file id="56098"><area-name id="233"/></rom-file>
+                    <rom-file id="56096"><area-name id="231"/></rom-file>
+                    <rom-file id="56097"><area-name id="232"/></rom-file>
+                    <rom-file id="56095"><area-name id="230"/></rom-file>
+                </category>
+                <category><name><region-name id="001"/></name>
+                    <rom-file id="56100"><area-name id="235"/></rom-file>
+                    <rom-file id="56099"><area-name id="234"/></rom-file>
+                    <rom-file id="56102"><area-name id="237"/></rom-file>
+                    <rom-file id="56101"><area-name id="236"/></rom-file>
+                </category>
+                <category><name><region-name id="002"/></name>
+                    <rom-file id="56107"><area-name id="242"/></rom-file>
+                    <rom-file id="56105"><area-name id="240"/></rom-file>
+                    <rom-file id="56104"><area-name id="239"/></rom-file>
+                    <rom-file id="56103"><area-name id="238"/></rom-file>
+                    <rom-file id="56106"><area-name id="241"/></rom-file>
+                </category>
+                <category><name><region-name id="003"/></name>
+                    <rom-file id="56110"><area-name id="245"/></rom-file>
+                    <rom-file id="56111"><area-name id="246"/></rom-file>
+                    <rom-file id="56108"><area-name id="243"/></rom-file>
+                    <rom-file id="56109"><area-name id="244"/></rom-file>
+                </category>
+                <category><name><region-name id="004"/></name>
+                    <rom-file id="56032"><area-name id="167"/></rom-file>
+                    <rom-file id="55966"><area-name id="101"/></rom-file>
+                    <rom-file id="56006"><area-name id="141"/></rom-file>
+                    <rom-file id="56005"><area-name id="140"/></rom-file>
+                    <rom-file id="56004"><area-name id="139"/></rom-file>
+                    <rom-file id="56055"><area-name id="190"/></rom-file>
+                    <rom-file id="55965"><area-name id="100"/></rom-file>
+                    <rom-file id="56007"><area-name id="142"/></rom-file>
+                </category>
+                <category><name><region-name id="005"/></name>
+                    <rom-file id="56061"><area-name id="196"/></rom-file>
+                    <rom-file id="55973"><area-name id="108"/></rom-file>
+                    <rom-file id="55967"><area-name id="102"/></rom-file>
+                    <rom-file id="56058"><area-name id="193"/></rom-file>
+                    <rom-file id="56113"><area-name id="248"/></rom-file>
+                    <rom-file id="55968"><area-name id="103"/></rom-file>
+                </category>
+                <category><name><region-name id="006"/></name>
+                    <rom-file id="55970"><area-name id="105"/></rom-file>
+                    <rom-file id="55867"><area-name id="002"/></rom-file>
+                    <rom-file id="56014"><area-name id="149"/></rom-file>
+                    <rom-file id="55969"><area-name id="104"/></rom-file>
+                    <rom-file id="56015"><area-name id="150"/></rom-file>
+                    <rom-file id="55866"><area-name id="001"/></rom-file>
+                    <rom-file id="56060"><area-name id="195"/></rom-file>
+                </category>
+                <category><name><region-name id="007"/></name>
+                    <rom-file id="56056"><area-name id="191"/></rom-file>
+                    <rom-file id="56038"><area-name id="173"/></rom-file>
+                    <rom-file id="55971"><area-name id="106"/></rom-file>
+                    <rom-file id="56008"><area-name id="143"/></rom-file>
+                    <rom-file id="55972"><area-name id="107"/></rom-file>
+                    <rom-file id="56009"><area-name id="144"/></rom-file>
+                    <rom-file id="56037"><area-name id="172"/></rom-file>
+                </category>
+                <category><name><region-name id="008"/></name>
+                    <rom-file id="56012"><area-name id="147"/></rom-file>
+                    <rom-file id="56062"><area-name id="197"/></rom-file>
+                    <rom-file id="55974"><area-name id="109"/></rom-file>
+                    <rom-file id="56013"><area-name id="148"/></rom-file>
+                    <rom-file id="55975"><area-name id="110"/></rom-file>
+                </category>
+                <category><name><region-name id="009"/></name>
+                    <rom-file id="56011"><area-name id="146"/></rom-file>
+                    <rom-file id="55981"><area-name id="116"/></rom-file>
+                    <rom-file id="56035"><area-name id="170"/></rom-file>
+                    <rom-file id="56010"><area-name id="145"/></rom-file>
+                    <rom-file id="56057"><area-name id="192"/></rom-file>
+                    <rom-file id="56059"><area-name id="194"/></rom-file>
+                    <rom-file id="56034"><area-name id="169"/></rom-file>
+                    <rom-file id="55980"><area-name id="115"/></rom-file>
+                </category>
+                <category><name><region-name id="010"/></name>
+                    <rom-file id="55869"><area-name id="004"/></rom-file>
+                    <rom-file id="55983"><area-name id="118"/></rom-file>
+                    <rom-file id="56078"><area-name id="213"/></rom-file>
+                    <rom-file id="55868"><area-name id="003"/></rom-file>
+                    <rom-file id="56063"><area-name id="198"/></rom-file>
+                    <rom-file id="56114"><area-name id="249"/></rom-file>
+                    <rom-file id="55982"><area-name id="117"/></rom-file>
+                </category>
+                <category><name><region-name id="011"/></name>
+                    <rom-file id="56017"><area-name id="152"/></rom-file>
+                    <rom-file id="55872"><area-name id="007"/></rom-file>
+                    <rom-file id="55873"><area-name id="008"/></rom-file>
+                    <rom-file id="56016"><area-name id="151"/></rom-file>
+                    <rom-file id="56065"><area-name id="200"/></rom-file>
+                    <rom-file id="55984"><area-name id="119"/></rom-file>
+                    <rom-file id="55985"><area-name id="120"/></rom-file>
+                </category>
+                <category><name><region-name id="012"/></name>
+                    <rom-file id="55976"><area-name id="111"/></rom-file>
+                    <rom-file id="56068"><area-name id="203"/></rom-file>
+                    <rom-file id="56069"><area-name id="204"/></rom-file>
+                    <rom-file id="55874"><area-name id="009"/></rom-file>
+                    <rom-file id="56071"><area-name id="206"/></rom-file>
+                    <rom-file id="56031"><area-name id="166"/></rom-file>
+                    <rom-file id="55875"><area-name id="010"/></rom-file>
+                </category>
+                <category><name><region-name id="013"/></name>
+                    <rom-file id="55871"><area-name id="006"/></rom-file>
+                    <rom-file id="56026"><area-name id="161"/></rom-file>
+                    <rom-file id="56027"><area-name id="162"/></rom-file>
+                    <rom-file id="56030"><area-name id="165"/></rom-file>
+                    <rom-file id="55870"><area-name id="005"/></rom-file>
+                    <rom-file id="55977"><area-name id="112"/></rom-file>
+                </category>
+                <category><name><region-name id="014"/></name>
+                    <rom-file id="55992"><area-name id="127"/></rom-file>
+                    <rom-file id="56049"><area-name id="184"/></rom-file>
+                    <rom-file id="56022"><area-name id="157"/></rom-file>
+                    <rom-file id="55996"><area-name id="131"/></rom-file>
+                    <rom-file id="55991"><area-name id="126"/></rom-file>
+                    <rom-file id="56044"><area-name id="179"/></rom-file>
+                    <rom-file id="56023"><area-name id="158"/></rom-file>
+                </category>
+            </category>
+            <category><name>&amp;<i18n-string id="FFXI2"/></name>
+                <category><name><region-name id="015"/></name>
+                    <rom-file id="56067"><area-name id="202"/></rom-file>
+                    <rom-file id="56019"><area-name id="154"/></rom-file>
+                    <rom-file id="56116"><area-name id="251"/></rom-file>
+                    <rom-file id="55987"><area-name id="122"/></rom-file>
+                    <rom-file id="56018"><area-name id="153"/></rom-file>
+                    <rom-file id="55986"><area-name id="121"/></rom-file>
+                </category>
+                <category><name><region-name id="016"/></name>
+                    <rom-file id="56033"><area-name id="168"/></rom-file>
+                    <rom-file id="56074"><area-name id="209"/></rom-file>
+                    <rom-file id="55979"><area-name id="114"/></rom-file>
+                    <rom-file id="56073"><area-name id="208"/></rom-file>
+                    <rom-file id="56112"><area-name id="247"/></rom-file>
+                    <rom-file id="55990"><area-name id="125"/></rom-file>
+                </category>
+                <category><name><region-name id="017"/></name>
+                    <rom-file id="55978"><area-name id="113"/></rom-file>
+                    <rom-file id="56066"><area-name id="201"/></rom-file>
+                    <rom-file id="56077"><area-name id="212"/></rom-file>
+                    <rom-file id="56039"><area-name id="174"/></rom-file>
+                    <rom-file id="55993"><area-name id="128"/></rom-file>
+                </category>
+                <category><name><region-name id="018"/></name>
+                    <rom-file id="56115"><area-name id="250"/></rom-file>
+                    <rom-file id="56117"><area-name id="252"/></rom-file>
+                    <rom-file id="56041"><area-name id="176"/></rom-file>
+                    <rom-file id="55988"><area-name id="123"/></rom-file>
+                </category>
+                <category><name><region-name id="019"/></name>
+                    <rom-file id="56072"><area-name id="207"/></rom-file>
+                    <rom-file id="56076"><area-name id="211"/></rom-file>
+                    <rom-file id="56025"><area-name id="160"/></rom-file>
+                    <rom-file id="56070"><area-name id="205"/></rom-file>
+                    <rom-file id="56028"><area-name id="163"/></rom-file>
+                    <rom-file id="56024"><area-name id="159"/></rom-file>
+                    <rom-file id="55989"><area-name id="124"/></rom-file>
+                </category>
+                <category><name><region-name id="020"/></name>
+                    <rom-file id="56045"><area-name id="180"/></rom-file>
+                    <rom-file id="55995"><area-name id="130"/></rom-file>
+                    <rom-file id="56046"><area-name id="181"/></rom-file>
+                    <rom-file id="56043"><area-name id="178"/></rom-file>
+                    <rom-file id="56042"><area-name id="177"/></rom-file>
+                </category>
+                <category><name><region-name id="021"/></name>
+                    <rom-file id="55999"><area-name id="134"/></rom-file>
+                    <rom-file id="56000"><area-name id="135"/></rom-file>
+                    <rom-file id="55905"><area-name id="040"/></rom-file>
+                    <rom-file id="56050"><area-name id="185"/></rom-file>
+                    <rom-file id="55906"><area-name id="041"/></rom-file>
+                    <rom-file id="56051"><area-name id="186"/></rom-file>
+                    <rom-file id="55907"><area-name id="042"/></rom-file>
+                    <rom-file id="55904"><area-name id="039"/></rom-file>
+                    <rom-file id="56052"><area-name id="187"/></rom-file>
+                    <rom-file id="56053"><area-name id="188"/></rom-file>
+                </category>
+            </category>
+            <category><name>&amp;<i18n-string id="FFXI3"/></name>
+                <category><name><region-name id="022"/></name>
+                    <rom-file id="55877"><area-name id="012"/></rom-file>
+                    <rom-file id="55878"><area-name id="013"/></rom-file>
+                    <rom-file id="55876"><area-name id="011"/></rom-file>
+                </category>
+                <category><name><region-name id="023"/></name>
+                    <rom-file id="55891"><area-name id="026"/></rom-file>
+                </category>
+                <category><name><region-name id="024"/></name>
+                    <rom-file id="55889"><area-name id="024"/></rom-file>
+                    <rom-file id="55890"><area-name id="025"/></rom-file>
+                    <rom-file id="55892"><area-name id="027"/></rom-file>
+                    <rom-file id="55893"><area-name id="028"/></rom-file>
+                    <rom-file id="55894"><area-name id="029"/></rom-file>
+                    <rom-file id="55895"><area-name id="030"/></rom-file>
+                    <rom-file id="55896"><area-name id="031"/></rom-file>
+                    <rom-file id="55897"><area-name id="032"/></rom-file>
+                </category>
+                <category><name><region-name id="025"/></name>
+                    <rom-file id="55879"><area-name id="014"/></rom-file>
+                    <rom-file id="55883"><area-name id="018"/></rom-file>
+                    <rom-file id="55881"><area-name id="016"/></rom-file>
+                    <rom-file id="55885"><area-name id="020"/></rom-file>
+                    <rom-file id="55887"><area-name id="022"/></rom-file>
+                    <rom-file id="55884"><area-name id="019"/></rom-file>
+                    <rom-file id="55882"><area-name id="017"/></rom-file>
+                    <rom-file id="55886"><area-name id="021"/></rom-file>
+                    <rom-file id="55888"><area-name id="023"/></rom-file>
+                </category>
+                <category><name><region-name id="026"/></name>
+                    <rom-file id="55898"><area-name id="033"/></rom-file>
+                    <rom-file id="55901"><area-name id="036"/></rom-file>
+                    <rom-file id="55899"><area-name id="034"/></rom-file>
+                    <rom-file id="55900"><area-name id="035"/></rom-file>
+                </category>
+                <category><name><region-name id="027"/></name>
+                    <rom-file id="55903"><area-name id="038"/></rom-file>
+                    <rom-file id="55902"><area-name id="037"/></rom-file>
+                </category>
+            </category>
+            <category><name>&amp;<i18n-string id="FFXI4"/></name>
+                <category><name><region-name id="028"/></name></category>
+                <category><name><region-name id="029"/></name>
+                    <rom-file id="55915"><area-name id="050"/></rom-file>
+                    <rom-file id="55977"><area-name id="050"/>-2</rom-file>
+                    <rom-file id="55913"><area-name id="048"/></rom-file>
+                    <rom-file id="55917"><area-name id="052"/></rom-file>
+                    <rom-file id="55935"><area-name id="070"/></rom-file>
+                    <rom-file id="55936"><area-name id="071"/></rom-file>
+                </category>
+                <category><name><region-name id="030"/></name>
+                    <rom-file id="55933"><area-name id="068"/></rom-file>
+                    <rom-file id="55932"><area-name id="067"/></rom-file>
+                    <rom-file id="55930"><area-name id="065"/></rom-file>
+                    <rom-file id="55931"><area-name id="066"/></rom-file>
+                    <rom-file id="55916"><area-name id="051"/></rom-file>
+                </category>
+                <category><name><region-name id="031"/></name>
+                    <rom-file id="55927"><area-name id="062"/></rom-file>
+                    <rom-file id="55928"><area-name id="063"/></rom-file>
+                    <rom-file id="55926"><area-name id="061"/></rom-file>
+                    <rom-file id="55929"><area-name id="064"/></rom-file>
+                </category>
+                <category><name><region-name id="032"/></name>
+                    <rom-file id="55919"><area-name id="054"/></rom-file>
+                    <rom-file id="55944"><area-name id="079"/></rom-file>
+                    <rom-file id="55943"><area-name id="078"/></rom-file>
+                    <rom-file id="55920"><area-name id="055"/></rom-file>
+                    <rom-file id="55934"><area-name id="069"/></rom-file>
+                    <rom-file id="55918"><area-name id="053"/></rom-file>
+                    <rom-file id="55921"><area-name id="056"/></rom-file>
+                    <rom-file id="55922"><area-name id="057"/></rom-file>
+                    <rom-file id="55925"><area-name id="060"/></rom-file>
+                </category>
+                <category><name><region-name id="033"/></name>
+                    <rom-file id="55937"><area-name id="072"/></rom-file>
+                    <rom-file id="55939"><area-name id="074"/></rom-file>
+                    <rom-file id="55940"><area-name id="075"/></rom-file>
+                    <rom-file id="55942"><area-name id="077"/></rom-file>
+                    <rom-file id="55941"><area-name id="076"/></rom-file>
+                    <rom-file id="55938"><area-name id="073"/></rom-file>
+                </category>
+            </category>
+            <category><name>&amp;<i18n-string id="FFXI5"/></name>
+                <category><name><region-name id="034"/></name>
+                    <rom-file id="55946"><area-name id="081"/></rom-file>
+                    <rom-file id="55951"><area-name id="086"/></rom-file>
+                    <rom-file id="55945"><area-name id="080"/></rom-file>
+                </category>
+                <category><name><region-name id="035"/></name>
+                    <rom-file id="55949"><area-name id="084"/></rom-file>
+                    <rom-file id="55947"><area-name id="082"/></rom-file>
+                    <rom-file id="55950"><area-name id="085"/></rom-file>
+                    <rom-file id="56040"><area-name id="175"/></rom-file>
+                </category>
+                <category><name><region-name id="036"/></name>
+                    <rom-file id="55952"><area-name id="087"/></rom-file>
+                    <rom-file id="55954"><area-name id="089"/></rom-file>
+                    <rom-file id="55953"><area-name id="088"/></rom-file>
+                    <rom-file id="55958"><area-name id="093"/></rom-file>
+                </category>
+                <category><name><region-name id="037"/></name>
+                    <rom-file id="55957"><area-name id="092"/></rom-file>
+                    <rom-file id="56036"><area-name id="171"/></rom-file>
+                    <rom-file id="55955"><area-name id="090"/></rom-file>
+                    <rom-file id="55956"><area-name id="091"/></rom-file>
+                    <rom-file id="55948"><area-name id="083"/></rom-file>
+                </category>
+                <category><name><region-name id="038"/></name>
+                    <rom-file id="55961"><area-name id="096"/></rom-file>
+                    <rom-file id="55994"><area-name id="129"/></rom-file>
+                    <rom-file id="55960"><area-name id="095"/></rom-file>
+                    <rom-file id="55959"><area-name id="094"/></rom-file>
+                </category>
+                <category><name><region-name id="039"/></name>
+                    <rom-file id="55964"><area-name id="099"/></rom-file>
+                    <rom-file id="56029"><area-name id="164"/></rom-file>
+                    <rom-file id="55962"><area-name id="097"/></rom-file>
+                    <rom-file id="55963"><area-name id="098"/></rom-file>
+                </category>
+                <category><name><region-name id="040"/></name>
+                    <rom-file id="56001"><area-name id="136"/></rom-file>
+                </category>
+                <category><name><region-name id="041"/></name>
+                    <rom-file id="56003"><area-name id="138"/></rom-file>
+                    <rom-file id="56020"><area-name id="155"/></rom-file>
+                    <rom-file id="56021"><area-name id="156"/></rom-file>
+                    <rom-file id="56002"><area-name id="137"/></rom-file>
+                </category>
+                <category><name><region-name id="042"/></name>
+                </category>
+                <category><name><region-name id="043"/></name>
+                </category>
+                <category><name><region-name id="044"/></name>
+                </category>
+                <category><name><region-name id="045"/></name>
+                </category>
+                <category><name><region-name id="047"/></name>
+                    <rom-file id="56047"><area-name id="182"/></rom-file>
+                    <rom-file id="56087"><area-name id="222"/></rom-file>
+                </category>
+            </category>
+            <category><name><i18n-string id="Menu:Abyssea"/></name>
+                <rom-file id="56080"><area-name id="215"/></rom-file>
+                <rom-file id="55880"><area-name id="015"/></rom-file>
+                <rom-file id="55997"><area-name id="132"/></rom-file>
+                <rom-file id="56081"><area-name id="216"/></rom-file>
+                <rom-file id="55910"><area-name id="045"/></rom-file>
+                <rom-file id="56082"><area-name id="217"/></rom-file>
+                <rom-file id="56083"><area-name id="218"/></rom-file>
+                <rom-file id="56118"><area-name id="253"/></rom-file>
+                <rom-file id="56119"><area-name id="254"/></rom-file>
+                <rom-file id="56120"><area-name id="255"/></rom-file>
+            </category>
+            <category><name><i18n-string id="Menu:Other"/></name>
+                <rom-file id="56089"><area-name id="224"/></rom-file>
+                <rom-file id="56091"><area-name id="226"/></rom-file>
+                <rom-file id="56088"><area-name id="223"/></rom-file>
+                <rom-file id="56090"><area-name id="225"/></rom-file>
+                <separator/>
+                <rom-file id="56086"><area-name id="221"/></rom-file>
+                <rom-file id="56093"><area-name id="228"/> <i18n-string id="Menu:WithPirates"/></rom-file>
+                <rom-file id="56085"><area-name id="220"/></rom-file>
+                <rom-file id="56092"><area-name id="227"/> <i18n-string id="Menu:WithPirates"/></rom-file>
+                <separator/>
+                <rom-file id="55911"><area-name id="046"/></rom-file>
+                <rom-file id="55912"><area-name id="047"/></rom-file>
+                <rom-file id="55923"><area-name id="058"/></rom-file>
+                <rom-file id="55924"><area-name id="059"/></rom-file>
+                <separator/>
+                <rom-file id="55908"><area-name id="043"/></rom-file>
+                <rom-file id="55909"><area-name id="044"/></rom-file>
+                <rom-file id="56048"><area-name id="183"/></rom-file>
+                <separator/>
+                <rom-file id="55851"><i18n-string id="Menu:MonsterSkillNames"/></rom-file>
+            </category>
+        </category>
+        <!-- Japanese: 06120-06375 -->
+        <category><name><i18n-string id="Menu:Japanese"/></name>
+            <category><name>&amp;<i18n-string id="FFXI1"/></name>
+                <category><name><region-name id="000"/></name>
+                    <rom-file id="06353"><area-name id="233"/></rom-file>
+                    <rom-file id="06351"><area-name id="231"/></rom-file>
+                    <rom-file id="06352"><area-name id="232"/></rom-file>
+                    <rom-file id="06350"><area-name id="230"/></rom-file>
+                </category>
+                <category><name><region-name id="001"/></name>
+                    <rom-file id="06355"><area-name id="235"/></rom-file>
+                    <rom-file id="06354"><area-name id="234"/></rom-file>
+                    <rom-file id="06357"><area-name id="237"/></rom-file>
+                    <rom-file id="06356"><area-name id="236"/></rom-file>
+                </category>
+                <category><name><region-name id="002"/></name>
+                    <rom-file id="06362"><area-name id="242"/></rom-file>
+                    <rom-file id="06360"><area-name id="240"/></rom-file>
+                    <rom-file id="06359"><area-name id="239"/></rom-file>
+                    <rom-file id="06358"><area-name id="238"/></rom-file>
+                    <rom-file id="06361"><area-name id="241"/></rom-file>
+                </category>
+                <category><name><region-name id="003"/></name>
+                    <rom-file id="06365"><area-name id="245"/></rom-file>
+                    <rom-file id="06366"><area-name id="246"/></rom-file>
+                    <rom-file id="06363"><area-name id="243"/></rom-file>
+                    <rom-file id="06364"><area-name id="244"/></rom-file>
+                </category>
+                <category><name><region-name id="004"/></name>
+                    <rom-file id="06287"><area-name id="167"/></rom-file>
+                    <rom-file id="06221"><area-name id="101"/></rom-file>
+                    <rom-file id="06261"><area-name id="141"/></rom-file>
+                    <rom-file id="06260"><area-name id="140"/></rom-file>
+                    <rom-file id="06259"><area-name id="139"/></rom-file>
+                    <rom-file id="06310"><area-name id="190"/></rom-file>
+                    <rom-file id="06220"><area-name id="100"/></rom-file>
+                    <rom-file id="06262"><area-name id="142"/></rom-file>
+                </category>
+                <category><name><region-name id="005"/></name>
+                    <rom-file id="06316"><area-name id="196"/></rom-file>
+                    <rom-file id="06228"><area-name id="108"/></rom-file>
+                    <rom-file id="06222"><area-name id="102"/></rom-file>
+                    <rom-file id="06313"><area-name id="193"/></rom-file>
+                    <rom-file id="06368"><area-name id="248"/></rom-file>
+                    <rom-file id="06223"><area-name id="103"/></rom-file>
+                </category>
+                <category><name><region-name id="006"/></name>
+                    <rom-file id="06225"><area-name id="105"/></rom-file>
+                    <rom-file id="06122"><area-name id="002"/></rom-file>
+                    <rom-file id="06269"><area-name id="149"/></rom-file>
+                    <rom-file id="06224"><area-name id="104"/></rom-file>
+                    <rom-file id="06270"><area-name id="150"/></rom-file>
+                    <rom-file id="06121"><area-name id="001"/></rom-file>
+                    <rom-file id="06315"><area-name id="195"/></rom-file>
+                </category>
+                <category><name><region-name id="007"/></name>
+                    <rom-file id="06311"><area-name id="191"/></rom-file>
+                    <rom-file id="06293"><area-name id="173"/></rom-file>
+                    <rom-file id="06226"><area-name id="106"/></rom-file>
+                    <rom-file id="06263"><area-name id="143"/></rom-file>
+                    <rom-file id="06227"><area-name id="107"/></rom-file>
+                    <rom-file id="06264"><area-name id="144"/></rom-file>
+                    <rom-file id="06292"><area-name id="172"/></rom-file>
+                </category>
+                <category><name><region-name id="008"/></name>
+                    <rom-file id="06267"><area-name id="147"/></rom-file>
+                    <rom-file id="06317"><area-name id="197"/></rom-file>
+                    <rom-file id="06229"><area-name id="109"/></rom-file>
+                    <rom-file id="06268"><area-name id="148"/></rom-file>
+                    <rom-file id="06230"><area-name id="110"/></rom-file>
+                </category>
+                <category><name><region-name id="009"/></name>
+                    <rom-file id="06266"><area-name id="146"/></rom-file>
+                    <rom-file id="06236"><area-name id="116"/></rom-file>
+                    <rom-file id="06290"><area-name id="170"/></rom-file>
+                    <rom-file id="06265"><area-name id="145"/></rom-file>
+                    <rom-file id="06312"><area-name id="192"/></rom-file>
+                    <rom-file id="06314"><area-name id="194"/></rom-file>
+                    <rom-file id="06289"><area-name id="169"/></rom-file>
+                    <rom-file id="06235"><area-name id="115"/></rom-file>
+                </category>
+                <category><name><region-name id="010"/></name>
+                    <rom-file id="06124"><area-name id="004"/></rom-file>
+                    <rom-file id="06238"><area-name id="118"/></rom-file>
+                    <rom-file id="06333"><area-name id="213"/></rom-file>
+                    <rom-file id="06123"><area-name id="003"/></rom-file>
+                    <rom-file id="06318"><area-name id="198"/></rom-file>
+                    <rom-file id="06369"><area-name id="249"/></rom-file>
+                    <rom-file id="06237"><area-name id="117"/></rom-file>
+                </category>
+                <category><name><region-name id="011"/></name>
+                    <rom-file id="06272"><area-name id="152"/></rom-file>
+                    <rom-file id="06127"><area-name id="007"/></rom-file>
+                    <rom-file id="06128"><area-name id="008"/></rom-file>
+                    <rom-file id="06271"><area-name id="151"/></rom-file>
+                    <rom-file id="06320"><area-name id="200"/></rom-file>
+                    <rom-file id="06239"><area-name id="119"/></rom-file>
+                    <rom-file id="06240"><area-name id="120"/></rom-file>
+                </category>
+                <category><name><region-name id="012"/></name>
+                    <rom-file id="06231"><area-name id="111"/></rom-file>
+                    <rom-file id="06323"><area-name id="203"/></rom-file>
+                    <rom-file id="06324"><area-name id="204"/></rom-file>
+                    <rom-file id="06129"><area-name id="009"/></rom-file>
+                    <rom-file id="06326"><area-name id="206"/></rom-file>
+                    <rom-file id="06286"><area-name id="166"/></rom-file>
+                    <rom-file id="06130"><area-name id="010"/></rom-file>
+                </category>
+                <category><name><region-name id="013"/></name>
+                    <rom-file id="06126"><area-name id="006"/></rom-file>
+                    <rom-file id="06281"><area-name id="161"/></rom-file>
+                    <rom-file id="06282"><area-name id="162"/></rom-file>
+                    <rom-file id="06285"><area-name id="165"/></rom-file>
+                    <rom-file id="06125"><area-name id="005"/></rom-file>
+                    <rom-file id="06232"><area-name id="112"/></rom-file>
+                </category>
+                <category><name><region-name id="014"/></name>
+                    <rom-file id="06247"><area-name id="127"/></rom-file>
+                    <rom-file id="06304"><area-name id="184"/></rom-file>
+                    <rom-file id="06277"><area-name id="157"/></rom-file>
+                    <rom-file id="06251"><area-name id="131"/></rom-file>
+                    <rom-file id="06246"><area-name id="126"/></rom-file>
+                    <rom-file id="06299"><area-name id="179"/></rom-file>
+                    <rom-file id="06278"><area-name id="158"/></rom-file>
+                </category>
+            </category>
+            <category><name>&amp;<i18n-string id="FFXI2"/></name>
+                <category><name><region-name id="015"/></name>
+                    <rom-file id="06322"><area-name id="202"/></rom-file>
+                    <rom-file id="06274"><area-name id="154"/></rom-file>
+                    <rom-file id="06371"><area-name id="251"/></rom-file>
+                    <rom-file id="06242"><area-name id="122"/></rom-file>
+                    <rom-file id="06273"><area-name id="153"/></rom-file>
+                    <rom-file id="06241"><area-name id="121"/></rom-file>
+                </category>
+                <category><name><region-name id="016"/></name>
+                    <rom-file id="06288"><area-name id="168"/></rom-file>
+                    <rom-file id="06329"><area-name id="209"/></rom-file>
+                    <rom-file id="06234"><area-name id="114"/></rom-file>
+                    <rom-file id="06328"><area-name id="208"/></rom-file>
+                    <rom-file id="06367"><area-name id="247"/></rom-file>
+                    <rom-file id="06245"><area-name id="125"/></rom-file>
+                </category>
+                <category><name><region-name id="017"/></name>
+                    <rom-file id="06233"><area-name id="113"/></rom-file>
+                    <rom-file id="06321"><area-name id="201"/></rom-file>
+                    <rom-file id="06332"><area-name id="212"/></rom-file>
+                    <rom-file id="06294"><area-name id="174"/></rom-file>
+                    <rom-file id="06248"><area-name id="128"/></rom-file>
+                </category>
+                <category><name><region-name id="018"/></name>
+                    <rom-file id="06370"><area-name id="250"/></rom-file>
+                    <rom-file id="06372"><area-name id="252"/></rom-file>
+                    <rom-file id="06296"><area-name id="176"/></rom-file>
+                    <rom-file id="06243"><area-name id="123"/></rom-file>
+                </category>
+                <category><name><region-name id="019"/></name>
+                    <rom-file id="06327"><area-name id="207"/></rom-file>
+                    <rom-file id="06331"><area-name id="211"/></rom-file>
+                    <rom-file id="06280"><area-name id="160"/></rom-file>
+                    <rom-file id="06325"><area-name id="205"/></rom-file>
+                    <rom-file id="06283"><area-name id="163"/></rom-file>
+                    <rom-file id="06279"><area-name id="159"/></rom-file>
+                    <rom-file id="06244"><area-name id="124"/></rom-file>
+                </category>
+                <category><name><region-name id="020"/></name>
+                    <rom-file id="06300"><area-name id="180"/></rom-file>
+                    <rom-file id="06250"><area-name id="130"/></rom-file>
+                    <rom-file id="06301"><area-name id="181"/></rom-file>
+                    <rom-file id="06298"><area-name id="178"/></rom-file>
+                    <rom-file id="06297"><area-name id="177"/></rom-file>
+                </category>
+                <category><name><region-name id="021"/></name>
+                    <rom-file id="06254"><area-name id="134"/></rom-file>
+                    <rom-file id="06255"><area-name id="135"/></rom-file>
+                    <rom-file id="06160"><area-name id="040"/></rom-file>
+                    <rom-file id="06305"><area-name id="185"/></rom-file>
+                    <rom-file id="06161"><area-name id="041"/></rom-file>
+                    <rom-file id="06306"><area-name id="186"/></rom-file>
+                    <rom-file id="06162"><area-name id="042"/></rom-file>
+                    <rom-file id="06159"><area-name id="039"/></rom-file>
+                    <rom-file id="06307"><area-name id="187"/></rom-file>
+                    <rom-file id="06308"><area-name id="188"/></rom-file>
+                </category>
+            </category>
+            <category><name>&amp;<i18n-string id="FFXI3"/></name>
+                <category><name><region-name id="022"/></name>
+                    <rom-file id="06132"><area-name id="012"/></rom-file>
+                    <rom-file id="06133"><area-name id="013"/></rom-file>
+                    <rom-file id="06131"><area-name id="011"/></rom-file>
+                </category>
+                <category><name><region-name id="023"/></name>
+                    <rom-file id="06146"><area-name id="026"/></rom-file>
+                </category>
+                <category><name><region-name id="024"/></name>
+                    <rom-file id="06144"><area-name id="024"/></rom-file>
+                    <rom-file id="06145"><area-name id="025"/></rom-file>
+                    <rom-file id="06147"><area-name id="027"/></rom-file>
+                    <rom-file id="06148"><area-name id="028"/></rom-file>
+                    <rom-file id="06149"><area-name id="029"/></rom-file>
+                    <rom-file id="06150"><area-name id="030"/></rom-file>
+                    <rom-file id="06151"><area-name id="031"/></rom-file>
+                    <rom-file id="06152"><area-name id="032"/></rom-file>
+                </category>
+                <category><name><region-name id="025"/></name>
+                    <rom-file id="06134"><area-name id="014"/></rom-file>
+                    <rom-file id="06138"><area-name id="018"/></rom-file>
+                    <rom-file id="06136"><area-name id="016"/></rom-file>
+                    <rom-file id="06140"><area-name id="020"/></rom-file>
+                    <rom-file id="06142"><area-name id="022"/></rom-file>
+                    <rom-file id="06139"><area-name id="019"/></rom-file>
+                    <rom-file id="06137"><area-name id="017"/></rom-file>
+                    <rom-file id="06141"><area-name id="021"/></rom-file>
+                    <rom-file id="06143"><area-name id="023"/></rom-file>
+                </category>
+                <category><name><region-name id="026"/></name>
+                    <rom-file id="06153"><area-name id="033"/></rom-file>
+                    <rom-file id="06156"><area-name id="036"/></rom-file>
+                    <rom-file id="06154"><area-name id="034"/></rom-file>
+                    <rom-file id="06155"><area-name id="035"/></rom-file>
+                </category>
+                <category><name><region-name id="027"/></name>
+                    <rom-file id="06158"><area-name id="038"/></rom-file>
+                    <rom-file id="06157"><area-name id="037"/></rom-file>
+                </category>
+            </category>
+            <category><name>&amp;<i18n-string id="FFXI4"/></name>
+                <category><name><region-name id="028"/></name></category>
+                <category><name><region-name id="029"/></name>
+                    <rom-file id="06170"><area-name id="050"/></rom-file>
+                    <rom-file id="57913"><area-name id="050"/>-2</rom-file>
+                    <rom-file id="06168"><area-name id="048"/></rom-file>
+                    <rom-file id="06172"><area-name id="052"/></rom-file>
+                    <rom-file id="06190"><area-name id="070"/></rom-file>
+                    <rom-file id="06191"><area-name id="071"/></rom-file>
+                </category>
+                <category><name><region-name id="030"/></name>
+                    <rom-file id="06188"><area-name id="068"/></rom-file>
+                    <rom-file id="06187"><area-name id="067"/></rom-file>
+                    <rom-file id="06185"><area-name id="065"/></rom-file>
+                    <rom-file id="06186"><area-name id="066"/></rom-file>
+                    <rom-file id="06171"><area-name id="051"/></rom-file>
+                </category>
+                <category><name><region-name id="031"/></name>
+                    <rom-file id="06182"><area-name id="062"/></rom-file>
+                    <rom-file id="06183"><area-name id="063"/></rom-file>
+                    <rom-file id="06181"><area-name id="061"/></rom-file>
+                    <rom-file id="06184"><area-name id="064"/></rom-file>
+                </category>
+                <category><name><region-name id="032"/></name>
+                    <rom-file id="06174"><area-name id="054"/></rom-file>
+                    <rom-file id="06199"><area-name id="079"/></rom-file>
+                    <rom-file id="06198"><area-name id="078"/></rom-file>
+                    <rom-file id="06175"><area-name id="055"/></rom-file>
+                    <rom-file id="06189"><area-name id="069"/></rom-file>
+                    <rom-file id="06173"><area-name id="053"/></rom-file>
+                    <rom-file id="06176"><area-name id="056"/></rom-file>
+                    <rom-file id="06177"><area-name id="057"/></rom-file>
+                    <rom-file id="06180"><area-name id="060"/></rom-file>
+                </category>
+                <category><name><region-name id="033"/></name>
+                    <rom-file id="06192"><area-name id="072"/></rom-file>
+                    <rom-file id="06194"><area-name id="074"/></rom-file>
+                    <rom-file id="06195"><area-name id="075"/></rom-file>
+                    <rom-file id="06197"><area-name id="077"/></rom-file>
+                    <rom-file id="06196"><area-name id="076"/></rom-file>
+                    <rom-file id="06193"><area-name id="073"/></rom-file>
+                </category>
+            </category>
+            <category><name>&amp;<i18n-string id="FFXI5"/></name>
+                <category><name><region-name id="034"/></name>
+                    <rom-file id="06201"><area-name id="081"/></rom-file>
+                    <rom-file id="06206"><area-name id="086"/></rom-file>
+                    <rom-file id="06200"><area-name id="080"/></rom-file>
+                </category>
+                <category><name><region-name id="035"/></name>
+                    <rom-file id="06204"><area-name id="084"/></rom-file>
+                    <rom-file id="06202"><area-name id="082"/></rom-file>
+                    <rom-file id="06205"><area-name id="085"/></rom-file>
+                    <rom-file id="06295"><area-name id="175"/></rom-file>
+                </category>
+                <category><name><region-name id="036"/></name>
+                    <rom-file id="06207"><area-name id="087"/></rom-file>
+                    <rom-file id="06209"><area-name id="089"/></rom-file>
+                    <rom-file id="06208"><area-name id="088"/></rom-file>
+                    <rom-file id="06213"><area-name id="093"/></rom-file>
+                </category>
+                <category><name><region-name id="037"/></name>
+                    <rom-file id="06212"><area-name id="092"/></rom-file>
+                    <rom-file id="06291"><area-name id="171"/></rom-file>
+                    <rom-file id="06210"><area-name id="090"/></rom-file>
+                    <rom-file id="06211"><area-name id="091"/></rom-file>
+                    <rom-file id="06203"><area-name id="083"/></rom-file>
+                </category>
+                <category><name><region-name id="038"/></name>
+                    <rom-file id="06216"><area-name id="096"/></rom-file>
+                    <rom-file id="06249"><area-name id="129"/></rom-file>
+                    <rom-file id="06215"><area-name id="095"/></rom-file>
+                    <rom-file id="06214"><area-name id="094"/></rom-file>
+                </category>
+                <category><name><region-name id="039"/></name>
+                    <rom-file id="06219"><area-name id="099"/></rom-file>
+                    <rom-file id="06284"><area-name id="164"/></rom-file>
+                    <rom-file id="06217"><area-name id="097"/></rom-file>
+                    <rom-file id="06218"><area-name id="098"/></rom-file>
+                </category>
+                <category><name><region-name id="040"/></name>
+                    <rom-file id="06256"><area-name id="136"/></rom-file>
+                </category>
+                <category><name><region-name id="041"/></name>
+                    <rom-file id="06258"><area-name id="138"/></rom-file>
+                    <rom-file id="06275"><area-name id="155"/></rom-file>
+                    <rom-file id="06276"><area-name id="156"/></rom-file>
+                    <rom-file id="06257"><area-name id="137"/></rom-file>
+                </category>
+                <category><name><region-name id="042"/></name>
+                </category>
+                <category><name><region-name id="043"/></name>
+                </category>
+                <category><name><region-name id="044"/></name>
+                </category>
+                <category><name><region-name id="045"/></name>
+                </category>
+                <category><name><region-name id="047"/></name>
+                    <rom-file id="06302"><area-name id="182"/></rom-file>
+                    <rom-file id="06342"><area-name id="222"/></rom-file>
+                </category>
+            </category>
+            <category><name><i18n-string id="Menu:Abyssea"/></name>
+                <rom-file id="06335"><area-name id="215"/></rom-file>
+                <rom-file id="06135"><area-name id="015"/></rom-file>
+                <rom-file id="06252"><area-name id="132"/></rom-file>
+                <rom-file id="06336"><area-name id="216"/></rom-file>
+                <rom-file id="06165"><area-name id="045"/></rom-file>
+                <rom-file id="06337"><area-name id="217"/></rom-file>
+                <rom-file id="06338"><area-name id="218"/></rom-file>
+                <rom-file id="06373"><area-name id="253"/></rom-file>
+                <rom-file id="06174"><area-name id="254"/></rom-file>
+                <rom-file id="06375"><area-name id="255"/></rom-file>
+            </category>
+            <category><name><i18n-string id="Menu:Other"/></name>
+                <rom-file id="06344"><area-name id="224"/></rom-file>
+                <rom-file id="06346"><area-name id="226"/></rom-file>
+                <rom-file id="06343"><area-name id="223"/></rom-file>
+                <rom-file id="06345"><area-name id="225"/></rom-file>
+                <separator/>
+                <rom-file id="06341"><area-name id="221"/></rom-file>
+                <rom-file id="06348"><area-name id="228"/> <i18n-string id="Menu:WithPirates"/></rom-file>
+                <rom-file id="06340"><area-name id="220"/></rom-file>
+                <rom-file id="06347"><area-name id="227"/> <i18n-string id="Menu:WithPirates"/></rom-file>
+                <separator/>
+                <rom-file id="06166"><area-name id="046"/></rom-file>
+                <rom-file id="06167"><area-name id="047"/></rom-file>
+                <rom-file id="06178"><area-name id="058"/></rom-file>
+                <rom-file id="06179"><area-name id="059"/></rom-file>
+                <separator/>
+                <rom-file id="06163"><area-name id="043"/></rom-file>
+                <rom-file id="06164"><area-name id="044"/></rom-file>
+                <rom-file id="06303"><area-name id="183"/></rom-file>
+                <separator/>
+                <rom-file id="07034"><i18n-string id="Menu:MonsterSkillNames"/></rom-file>
+            </category>
+        </category>
     </category>
-    <!-- French: 56285-56540 -->
-    <category><name><i18n-string id="Menu:French"/></name>
-      <category><name>&amp;<i18n-string id="FFXI1"/></name>
-	<category><name><region-name id="000"/></name>
-	  <rom-file id="56518"><area-name id="233"/></rom-file>
-	  <rom-file id="56516"><area-name id="231"/></rom-file>
-	  <rom-file id="56517"><area-name id="232"/></rom-file>
-	  <rom-file id="56515"><area-name id="230"/></rom-file>
-	</category>
-	<category><name><region-name id="001"/></name>
-	  <rom-file id="56520"><area-name id="235"/></rom-file>
-	  <rom-file id="56519"><area-name id="234"/></rom-file>
-	  <rom-file id="56522"><area-name id="237"/></rom-file>
-	  <rom-file id="56521"><area-name id="236"/></rom-file>
-	</category>
-	<category><name><region-name id="002"/></name>
-	  <rom-file id="56527"><area-name id="242"/></rom-file>
-	  <rom-file id="56525"><area-name id="240"/></rom-file>
-	  <rom-file id="56524"><area-name id="239"/></rom-file>
-	  <rom-file id="56523"><area-name id="238"/></rom-file>
-	  <rom-file id="56526"><area-name id="241"/></rom-file>
-	</category>
-	<category><name><region-name id="003"/></name>
-	  <rom-file id="56530"><area-name id="245"/></rom-file>
-	  <rom-file id="56531"><area-name id="246"/></rom-file>
-	  <rom-file id="56528"><area-name id="243"/></rom-file>
-	  <rom-file id="56529"><area-name id="244"/></rom-file>
-	</category>
-	<category><name><region-name id="004"/></name>
-	  <rom-file id="56452"><area-name id="167"/></rom-file>
-	  <rom-file id="56386"><area-name id="101"/></rom-file>
-	  <rom-file id="56426"><area-name id="141"/></rom-file>
-	  <rom-file id="56425"><area-name id="140"/></rom-file>
-	  <rom-file id="56424"><area-name id="139"/></rom-file>
-	  <rom-file id="56475"><area-name id="190"/></rom-file>
-	  <rom-file id="56385"><area-name id="100"/></rom-file>
-	  <rom-file id="56427"><area-name id="142"/></rom-file>
-	</category>
-	<category><name><region-name id="005"/></name>
-	  <rom-file id="56481"><area-name id="196"/></rom-file>
-	  <rom-file id="56393"><area-name id="108"/></rom-file>
-	  <rom-file id="56387"><area-name id="102"/></rom-file>
-	  <rom-file id="56478"><area-name id="193"/></rom-file>
-	  <rom-file id="56533"><area-name id="248"/></rom-file>
-	  <rom-file id="56388"><area-name id="103"/></rom-file>
-	</category>
-	<category><name><region-name id="006"/></name>
-	  <rom-file id="56390"><area-name id="105"/></rom-file>
-	  <rom-file id="56287"><area-name id="002"/></rom-file>
-	  <rom-file id="56434"><area-name id="149"/></rom-file>
-	  <rom-file id="56389"><area-name id="104"/></rom-file>
-	  <rom-file id="56435"><area-name id="150"/></rom-file>
-	  <rom-file id="56286"><area-name id="001"/></rom-file>
-	  <rom-file id="56480"><area-name id="195"/></rom-file>
-	</category>
-	<category><name><region-name id="007"/></name>
-	  <rom-file id="56476"><area-name id="191"/></rom-file>
-	  <rom-file id="56458"><area-name id="173"/></rom-file>
-	  <rom-file id="56391"><area-name id="106"/></rom-file>
-	  <rom-file id="56428"><area-name id="143"/></rom-file>
-	  <rom-file id="56392"><area-name id="107"/></rom-file>
-	  <rom-file id="56429"><area-name id="144"/></rom-file>
-	  <rom-file id="56457"><area-name id="172"/></rom-file>
-	</category>
-	<category><name><region-name id="008"/></name>
-	  <rom-file id="56432"><area-name id="147"/></rom-file>
-	  <rom-file id="56482"><area-name id="197"/></rom-file>
-	  <rom-file id="56394"><area-name id="109"/></rom-file>
-	  <rom-file id="56433"><area-name id="148"/></rom-file>
-	  <rom-file id="56395"><area-name id="110"/></rom-file>
-	</category>
-	<category><name><region-name id="009"/></name>
-	  <rom-file id="56431"><area-name id="146"/></rom-file>
-	  <rom-file id="56401"><area-name id="116"/></rom-file>
-	  <rom-file id="56455"><area-name id="170"/></rom-file>
-	  <rom-file id="56430"><area-name id="145"/></rom-file>
-	  <rom-file id="56477"><area-name id="192"/></rom-file>
-	  <rom-file id="56479"><area-name id="194"/></rom-file>
-	  <rom-file id="56454"><area-name id="169"/></rom-file>
-	  <rom-file id="56400"><area-name id="115"/></rom-file>
-	</category>
-	<category><name><region-name id="010"/></name>
-	  <rom-file id="56289"><area-name id="004"/></rom-file>
-	  <rom-file id="56403"><area-name id="118"/></rom-file>
-	  <rom-file id="56498"><area-name id="213"/></rom-file>
-	  <rom-file id="56288"><area-name id="003"/></rom-file>
-	  <rom-file id="56483"><area-name id="198"/></rom-file>
-	  <rom-file id="56534"><area-name id="249"/></rom-file>
-	  <rom-file id="56402"><area-name id="117"/></rom-file>
-	</category>
-	<category><name><region-name id="011"/></name>
-	  <rom-file id="56437"><area-name id="152"/></rom-file>
-	  <rom-file id="56292"><area-name id="007"/></rom-file>
-	  <rom-file id="56293"><area-name id="008"/></rom-file>
-	  <rom-file id="56436"><area-name id="151"/></rom-file>
-	  <rom-file id="56485"><area-name id="200"/></rom-file>
-	  <rom-file id="56404"><area-name id="119"/></rom-file>
-	  <rom-file id="56405"><area-name id="120"/></rom-file>
-	</category>
-	<category><name><region-name id="012"/></name>
-	  <rom-file id="56396"><area-name id="111"/></rom-file>
-	  <rom-file id="56488"><area-name id="203"/></rom-file>
-	  <rom-file id="56489"><area-name id="204"/></rom-file>
-	  <rom-file id="56294"><area-name id="009"/></rom-file>
-	  <rom-file id="56491"><area-name id="206"/></rom-file>
-	  <rom-file id="56451"><area-name id="166"/></rom-file>
-	  <rom-file id="56295"><area-name id="010"/></rom-file>
-	</category>
-	<category><name><region-name id="013"/></name>
-	  <rom-file id="56291"><area-name id="006"/></rom-file>
-	  <rom-file id="56446"><area-name id="161"/></rom-file>
-	  <rom-file id="56447"><area-name id="162"/></rom-file>
-	  <rom-file id="56450"><area-name id="165"/></rom-file>
-	  <rom-file id="56290"><area-name id="005"/></rom-file>
-	  <rom-file id="56397"><area-name id="112"/></rom-file>
-	</category>
-	<category><name><region-name id="014"/></name>
-	  <rom-file id="56412"><area-name id="127"/></rom-file>
-	  <rom-file id="56469"><area-name id="184"/></rom-file>
-	  <rom-file id="56442"><area-name id="157"/></rom-file>
-	  <rom-file id="56416"><area-name id="131"/></rom-file>
-	  <rom-file id="56411"><area-name id="126"/></rom-file>
-	  <rom-file id="56464"><area-name id="179"/></rom-file>
-	  <rom-file id="56443"><area-name id="158"/></rom-file>
-	</category>
-      </category>
-      <category><name>&amp;<i18n-string id="FFXI2"/></name>
-	<category><name><region-name id="015"/></name>
-	  <rom-file id="56487"><area-name id="202"/></rom-file>
-	  <rom-file id="56439"><area-name id="154"/></rom-file>
-	  <rom-file id="56536"><area-name id="251"/></rom-file>
-	  <rom-file id="56407"><area-name id="122"/></rom-file>
-	  <rom-file id="56438"><area-name id="153"/></rom-file>
-	  <rom-file id="56406"><area-name id="121"/></rom-file>
-	</category>
-	<category><name><region-name id="016"/></name>
-	  <rom-file id="56453"><area-name id="168"/></rom-file>
-	  <rom-file id="56494"><area-name id="209"/></rom-file>
-	  <rom-file id="56399"><area-name id="114"/></rom-file>
-	  <rom-file id="56493"><area-name id="208"/></rom-file>
-	  <rom-file id="56532"><area-name id="247"/></rom-file>
-	  <rom-file id="56410"><area-name id="125"/></rom-file>
-	</category>
-	<category><name><region-name id="017"/></name>
-	  <rom-file id="56398"><area-name id="113"/></rom-file>
-	  <rom-file id="56486"><area-name id="201"/></rom-file>
-	  <rom-file id="56497"><area-name id="212"/></rom-file>
-	  <rom-file id="56459"><area-name id="174"/></rom-file>
-	  <rom-file id="56413"><area-name id="128"/></rom-file>
-	</category>
-	<category><name><region-name id="018"/></name>
-	  <rom-file id="56535"><area-name id="250"/></rom-file>
-	  <rom-file id="56537"><area-name id="252"/></rom-file>
-	  <rom-file id="56461"><area-name id="176"/></rom-file>
-	  <rom-file id="56408"><area-name id="123"/></rom-file>
-	</category>
-	<category><name><region-name id="019"/></name>
-	  <rom-file id="56492"><area-name id="207"/></rom-file>
-	  <rom-file id="56496"><area-name id="211"/></rom-file>
-	  <rom-file id="56445"><area-name id="160"/></rom-file>
-	  <rom-file id="56490"><area-name id="205"/></rom-file>
-	  <rom-file id="56448"><area-name id="163"/></rom-file>
-	  <rom-file id="56444"><area-name id="159"/></rom-file>
-	  <rom-file id="56409"><area-name id="124"/></rom-file>
-	</category>
-	<category><name><region-name id="020"/></name>
-	  <rom-file id="56465"><area-name id="180"/></rom-file>
-	  <rom-file id="56415"><area-name id="130"/></rom-file>
-	  <rom-file id="56466"><area-name id="181"/></rom-file>
-	  <rom-file id="56463"><area-name id="178"/></rom-file>
-	  <rom-file id="56462"><area-name id="177"/></rom-file>
-	</category>
-	<category><name><region-name id="021"/></name>
-	  <rom-file id="56419"><area-name id="134"/></rom-file>
-	  <rom-file id="56420"><area-name id="135"/></rom-file>
-	  <rom-file id="56325"><area-name id="040"/></rom-file>
-	  <rom-file id="56470"><area-name id="185"/></rom-file>
-	  <rom-file id="56326"><area-name id="041"/></rom-file>
-	  <rom-file id="56471"><area-name id="186"/></rom-file>
-	  <rom-file id="56327"><area-name id="042"/></rom-file>
-	  <rom-file id="56324"><area-name id="039"/></rom-file>
-	  <rom-file id="56472"><area-name id="187"/></rom-file>
-	  <rom-file id="56473"><area-name id="188"/></rom-file>
-	</category>
-      </category>
-      <category><name>&amp;<i18n-string id="FFXI3"/></name>
-	<category><name><region-name id="022"/></name>
-	  <rom-file id="56297"><area-name id="012"/></rom-file>
-	  <rom-file id="56298"><area-name id="013"/></rom-file>
-	  <rom-file id="56296"><area-name id="011"/></rom-file>
-	</category>
-	<category><name><region-name id="023"/></name>
-	  <rom-file id="56311"><area-name id="026"/></rom-file>
-	</category>
-	<category><name><region-name id="024"/></name>
-	  <rom-file id="56309"><area-name id="024"/></rom-file>
-	  <rom-file id="56310"><area-name id="025"/></rom-file>
-	  <rom-file id="56312"><area-name id="027"/></rom-file>
-	  <rom-file id="56313"><area-name id="028"/></rom-file>
-	  <rom-file id="56314"><area-name id="029"/></rom-file>
-	  <rom-file id="56315"><area-name id="030"/></rom-file>
-	  <rom-file id="56316"><area-name id="031"/></rom-file>
-	  <rom-file id="56317"><area-name id="032"/></rom-file>
-	</category>
-	<category><name><region-name id="025"/></name>
-	  <rom-file id="56299"><area-name id="014"/></rom-file>
-	  <rom-file id="56303"><area-name id="018"/></rom-file>
-	  <rom-file id="56301"><area-name id="016"/></rom-file>
-	  <rom-file id="56305"><area-name id="020"/></rom-file>
-	  <rom-file id="56307"><area-name id="022"/></rom-file>
-	  <rom-file id="56304"><area-name id="019"/></rom-file>
-	  <rom-file id="56302"><area-name id="017"/></rom-file>
-	  <rom-file id="56306"><area-name id="021"/></rom-file>
-	  <rom-file id="56308"><area-name id="023"/></rom-file>
-	</category>
-	<category><name><region-name id="026"/></name>
-	  <rom-file id="56318"><area-name id="033"/></rom-file>
-	  <rom-file id="56321"><area-name id="036"/></rom-file>
-	  <rom-file id="56319"><area-name id="034"/></rom-file>
-	  <rom-file id="56320"><area-name id="035"/></rom-file>
-	</category>
-	<category><name><region-name id="027"/></name>
-	  <rom-file id="56323"><area-name id="038"/></rom-file>
-	  <rom-file id="56322"><area-name id="037"/></rom-file>
-	</category>
-      </category>
-      <category><name>&amp;<i18n-string id="FFXI4"/></name>
-	<category><name><region-name id="028"/></name></category>
-	<category><name><region-name id="029"/></name>
-	  <rom-file id="56335"><area-name id="050"/></rom-file>
-	  <rom-file id="58009"><area-name id="050"/>-2</rom-file>
-	  <rom-file id="56333"><area-name id="048"/></rom-file>
-	  <rom-file id="56337"><area-name id="052"/></rom-file>
-	  <rom-file id="56355"><area-name id="070"/></rom-file>
-	  <rom-file id="56356"><area-name id="071"/></rom-file>
-	</category>
-	<category><name><region-name id="030"/></name>
-	  <rom-file id="56353"><area-name id="068"/></rom-file>
-	  <rom-file id="56352"><area-name id="067"/></rom-file>
-	  <rom-file id="56350"><area-name id="065"/></rom-file>
-	  <rom-file id="56351"><area-name id="066"/></rom-file>
-	  <rom-file id="56336"><area-name id="051"/></rom-file>
-	</category>
-	<category><name><region-name id="031"/></name>
-	  <rom-file id="56347"><area-name id="062"/></rom-file>
-	  <rom-file id="56348"><area-name id="063"/></rom-file>
-	  <rom-file id="56346"><area-name id="061"/></rom-file>
-	  <rom-file id="56349"><area-name id="064"/></rom-file>
-	</category>
-	<category><name><region-name id="032"/></name>
-	  <rom-file id="56339"><area-name id="054"/></rom-file>
-	  <rom-file id="56364"><area-name id="079"/></rom-file>
-	  <rom-file id="56363"><area-name id="078"/></rom-file>
-	  <rom-file id="56340"><area-name id="055"/></rom-file>
-	  <rom-file id="56354"><area-name id="069"/></rom-file>
-	  <rom-file id="56338"><area-name id="053"/></rom-file>
-	  <rom-file id="56341"><area-name id="056"/></rom-file>
-	  <rom-file id="56342"><area-name id="057"/></rom-file>
-	  <rom-file id="56345"><area-name id="060"/></rom-file>
-	</category>
-	<category><name><region-name id="033"/></name>
-	  <rom-file id="56357"><area-name id="072"/></rom-file>
-	  <rom-file id="56359"><area-name id="074"/></rom-file>
-	  <rom-file id="56360"><area-name id="075"/></rom-file>
-	  <rom-file id="56362"><area-name id="077"/></rom-file>
-	  <rom-file id="56361"><area-name id="076"/></rom-file>
-	  <rom-file id="56358"><area-name id="073"/></rom-file>
-	</category>
-      </category>
-      <category><name>&amp;<i18n-string id="FFXI5"/></name>
-	<category><name><region-name id="034"/></name>
-	  <rom-file id="56366"><area-name id="081"/></rom-file>
-	  <rom-file id="56371"><area-name id="086"/></rom-file>
-	  <rom-file id="56365"><area-name id="080"/></rom-file>
-	</category>
-	<category><name><region-name id="035"/></name>
-	  <rom-file id="56369"><area-name id="084"/></rom-file>
-	  <rom-file id="56367"><area-name id="082"/></rom-file>
-	  <rom-file id="56370"><area-name id="085"/></rom-file>
-	  <rom-file id="56460"><area-name id="175"/></rom-file>
-	</category>
-	<category><name><region-name id="036"/></name>
-	  <rom-file id="56372"><area-name id="087"/></rom-file>
-	  <rom-file id="56374"><area-name id="089"/></rom-file>
-	  <rom-file id="56373"><area-name id="088"/></rom-file>
-	  <rom-file id="56378"><area-name id="093"/></rom-file>
-	</category>
-	<category><name><region-name id="037"/></name>
-	  <rom-file id="56377"><area-name id="092"/></rom-file>
-	  <rom-file id="56466"><area-name id="171"/></rom-file>
-	  <rom-file id="56375"><area-name id="090"/></rom-file>
-	  <rom-file id="56376"><area-name id="091"/></rom-file>
-	  <rom-file id="56368"><area-name id="083"/></rom-file>
-	</category>
-	<category><name><region-name id="038"/></name>
-	  <rom-file id="56381"><area-name id="096"/></rom-file>
-	  <rom-file id="56414"><area-name id="129"/></rom-file>
-	  <rom-file id="56380"><area-name id="095"/></rom-file>
-	  <rom-file id="56379"><area-name id="094"/></rom-file>
-	</category>
-	<category><name><region-name id="039"/></name>
-	  <rom-file id="56384"><area-name id="099"/></rom-file>
-	  <rom-file id="56449"><area-name id="164"/></rom-file>
-	  <rom-file id="56382"><area-name id="097"/></rom-file>
-	  <rom-file id="56383"><area-name id="098"/></rom-file>
-	</category>
-	<category><name><region-name id="040"/></name>
-	  <rom-file id="56421"><area-name id="136"/></rom-file>
-	</category>
-	<category><name><region-name id="041"/></name>
-	  <rom-file id="56423"><area-name id="138"/></rom-file>
-	  <rom-file id="56440"><area-name id="155"/></rom-file>
-	  <rom-file id="56441"><area-name id="156"/></rom-file>
-	  <rom-file id="56422"><area-name id="137"/></rom-file>
-	</category>
-	<category><name><region-name id="042"/></name>
-	</category>
-	<category><name><region-name id="043"/></name>
-	</category>
-	<category><name><region-name id="044"/></name>
-	</category>
-	<category><name><region-name id="045"/></name>
-	</category>
-	<category><name><region-name id="047"/></name>
-		<rom-file id="56467"><area-name id="182"/></rom-file>
-		<rom-file id="56507"><area-name id="222"/></rom-file>
-	</category>
-      </category>
-      <category><name><i18n-string id="Menu:Abyssea"/></name>
-	<rom-file id="56500"><area-name id="215"/></rom-file>
-	<rom-file id="56300"><area-name id="015"/></rom-file>
-	<rom-file id="56417"><area-name id="132"/></rom-file>
-	<rom-file id="56501"><area-name id="216"/></rom-file>
-	<rom-file id="56330"><area-name id="045"/></rom-file>
-	<rom-file id="56502"><area-name id="217"/></rom-file>
-	<rom-file id="56503"><area-name id="218"/></rom-file>
-	<rom-file id="56528"><area-name id="253"/></rom-file>
-	<rom-file id="56529"><area-name id="254"/></rom-file>
-	<rom-file id="56530"><area-name id="255"/></rom-file>
-      </category>
-      <category><name><i18n-string id="Menu:Other"/></name>
-	<rom-file id="56509"><area-name id="224"/></rom-file>
-	<rom-file id="56511"><area-name id="226"/></rom-file>
-	<rom-file id="56508"><area-name id="223"/></rom-file>
-	<rom-file id="56510"><area-name id="225"/></rom-file>
-	<separator/>
-	<rom-file id="56506"><area-name id="221"/></rom-file>
-	<rom-file id="56513"><area-name id="228"/> <i18n-string id="Menu:WithPirates"/></rom-file>
-	<rom-file id="56505"><area-name id="220"/></rom-file>
-	<rom-file id="56512"><area-name id="227"/> <i18n-string id="Menu:WithPirates"/></rom-file>
-	<separator/>
-	<rom-file id="56331"><area-name id="046"/></rom-file>
-	<rom-file id="56332"><area-name id="047"/></rom-file>
-	<rom-file id="56343"><area-name id="058"/></rom-file>
-	<rom-file id="56344"><area-name id="059"/></rom-file>
-	<separator/>
-	<rom-file id="56328"><area-name id="043"/></rom-file>
-	<rom-file id="56329"><area-name id="044"/></rom-file>
-	<rom-file id="56468"><area-name id="183"/></rom-file>
-	<separator/>
-	<rom-file id="56271"><i18n-string id="Menu:MonsterSkillNames"/></rom-file>
-      </category>
+    <category><name><i18n-string id="Menu:Images"/></name>
+        <category><name><i18n-string id="Menu:Maps"/></name>
+            <category><name>&amp;<i18n-string id="FFXI1"/></name>
+                <category><name><region-name id="000"/></name>
+                    <category><name><region-name id="000"/></name>
+                        <rom-file id="05505"><i18n-string id="Menu:Highlight"/><area-name id="233"/></rom-file>
+                        <rom-file id="05503"><i18n-string id="Menu:Highlight"/><area-name id="231"/></rom-file>
+                        <rom-file id="05504"><i18n-string id="Menu:Highlight"/><area-name id="232"/></rom-file>
+                        <rom-file id="05480"><i18n-string id="Menu:Highlight"/><area-name id="230"/></rom-file>
+                    </category>
+                    <rom-file id="05479"><area-name id="233"/></rom-file>
+                    <rom-file id="05477"><area-name id="231"/></rom-file>
+                    <rom-file id="05478"><area-name id="232"/></rom-file>
+                    <rom-file id="05476"><area-name id="230"/></rom-file>
+                </category>
+                <category><name><region-name id="001"/></name>
+                    <category><name><region-name id="001"/></name>
+                        <rom-file id="05485"><i18n-string id="Menu:Highlight"/><area-name id="234"/></rom-file>
+                        <rom-file id="05506"><i18n-string id="Menu:Highlight"/><area-name id="235"/></rom-file>
+                        <rom-file id="05507"><i18n-string id="Menu:Highlight"/><area-name id="236"/></rom-file>
+                        <rom-file id="05508"><i18n-string id="Menu:Highlight"/><area-name id="237"/></rom-file>
+                    </category>
+                    <rom-file id="05481"><area-name id="234"/></rom-file>
+                    <rom-file id="05482"><area-name id="235"/></rom-file>
+                    <rom-file id="05483"><area-name id="236"/></rom-file>
+                    <rom-file id="05484"><area-name id="237"/></rom-file>
+                </category>
+                <category><name><region-name id="002"/></name>
+                    <category><name><region-name id="002"/></name>
+                        <rom-file id="05491"><i18n-string id="Menu:Highlight"/><area-name id="238"/></rom-file>
+                        <rom-file id="05509"><i18n-string id="Menu:Highlight"/><area-name id="239"/></rom-file>
+                        <rom-file id="05510"><i18n-string id="Menu:Highlight"/><area-name id="240"/></rom-file>
+                        <rom-file id="05511"><i18n-string id="Menu:Highlight"/><area-name id="241"/></rom-file>
+                    </category>
+                    <category><name><area-name id="238"/></name>
+                        <rom-file id="05486"><i18n-string id="Menu:Full"/></rom-file>
+                        <rom-file id="05501"><i18n-string id="Menu:NorthHalf"/></rom-file>
+                        <rom-file id="05502"><i18n-string id="Menu:SouthHalf"/></rom-file>
+                    </category>
+                    <rom-file id="05487"><area-name id="239"/></rom-file>
+                    <rom-file id="05488"><area-name id="240"/></rom-file>
+                    <rom-file id="05489"><area-name id="241"/></rom-file>
+                </category>
+                <category><name><region-name id="003"/></name>
+                    <category><name><region-name id="003"/></name>
+                        <rom-file id="05496"><i18n-string id="Menu:Highlight"/><area-name id="243"/></rom-file>
+                        <rom-file id="05512"><i18n-string id="Menu:Highlight"/><area-name id="244"/></rom-file>
+                        <rom-file id="05513"><i18n-string id="Menu:Highlight"/><area-name id="245"/></rom-file>
+                        <rom-file id="05514"><i18n-string id="Menu:Highlight"/><area-name id="246"/></rom-file>
+                    </category>
+                    <rom-file id="05492"><area-name id="243"/></rom-file>
+                    <rom-file id="05493"><area-name id="244"/></rom-file>
+                    <rom-file id="05494"><area-name id="245"/></rom-file>
+                    <rom-file id="05495"><area-name id="246"/></rom-file>
+                </category>
+                <category><name><region-name id="004"/></name>
+                    <category><name><area-name id="167"/></name>
+                        <rom-file id="05401"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="05402"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="05403"><i18n-string id="Menu:MapN"/>3</rom-file>
+                    </category>
+                    <rom-file id="05314"><area-name id="101"/></rom-file>
+                    <category><name><area-name id="140"/></name>
+                        <rom-file id="05340"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="05341"><i18n-string id="Menu:MapN"/>2</rom-file>
+                    </category>
+                    <rom-file id="05342"><area-name id="141"/></rom-file>
+                    <category><name><area-name id="190"/></name>
+                        <rom-file id="05425"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="05428"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="05429"><i18n-string id="Menu:MapN"/>3</rom-file>
+                        <rom-file id="05430"><i18n-string id="Menu:MapN"/>4</rom-file>
+                    </category>
+                    <rom-file id="05313"><area-name id="100"/></rom-file>
+                    <category><name><area-name id="142"/></name>
+                        <rom-file id="05343"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="05529"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="05530"><i18n-string id="Menu:MapN"/>3</rom-file>
+                    </category>
+                </category>
+                <category><name><region-name id="005"/></name>
+                    <category><name><area-name id="196"/></name>
+                        <rom-file id="05443"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="05444"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="05445"><i18n-string id="Menu:MapN"/>3</rom-file>
+                        <rom-file id="05446"><i18n-string id="Menu:MapN"/>4</rom-file>
+                        <rom-file id="05534"><i18n-string id="Menu:MapN"/>5</rom-file>
+                    </category>
+                    <rom-file id="05315"><area-name id="102"/></rom-file>
+                    <rom-file id="05321"><area-name id="108"/></rom-file>
+                    <category><name><area-name id="193"/></name>
+                        <rom-file id="05437"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="05438"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="05439"><i18n-string id="Menu:MapN"/>3</rom-file>
+                        <rom-file id="05531"><i18n-string id="Menu:MapN"/>4</rom-file>
+                    </category>
+                    <rom-file id="05497"><area-name id="248"/></rom-file>
+                    <rom-file id="05316"><area-name id="103"/></rom-file>
+                </category>
+                <category><name><region-name id="006"/></name>
+                    <rom-file id="05318"><area-name id="105"/></rom-file>
+                    <category><name><area-name id="002"/></name>
+                        <rom-file id="05689"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="05742"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="05742"><i18n-string id="Menu:MapN"/>3</rom-file>
+                    </category>
+                    <rom-file id="05355"><area-name id="149"/></rom-file>
+                    <rom-file id="05317"><area-name id="104"/></rom-file>
+                    <rom-file id="05356"><area-name id="150"/></rom-file>
+                    <rom-file id="05744"><area-name id="001"/></rom-file>
+                    <category><name><area-name id="195"/></name>
+                        <rom-file id="05440"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="05441"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="05442"><i18n-string id="Menu:MapN"/>3</rom-file>
+                        <rom-file id="05533"><i18n-string id="Menu:MapN"/>4</rom-file>
+                    </category>
+                </category>
+                <category><name><region-name id="007"/></name>
+                    <category><name><area-name id="191"/></name>
+                        <rom-file id="05426"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="05427"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="05431"><i18n-string id="Menu:MapN"/>3</rom-file>
+                    </category>
+                    <category><name><area-name id="173"/></name>
+                        <rom-file id="05410"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="05634"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="05635"><i18n-string id="Menu:MapN"/>3</rom-file>
+                        <rom-file id="05636"><i18n-string id="Menu:MapN"/>4</rom-file>
+                        <rom-file id="05637"><i18n-string id="Menu:MapN"/>5</rom-file>
+                        <rom-file id="05638"><i18n-string id="Menu:MapN"/>6</rom-file>
+                    </category>
+                    <rom-file id="05319"><area-name id="106"/></rom-file>
+                    <category><name><area-name id="143"/></name>
+                        <rom-file id="05344"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="05345"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="05346"><i18n-string id="Menu:MapN"/>3</rom-file>
+                    </category>
+                    <rom-file id="05320"><area-name id="107"/></rom-file>
+                    <rom-file id="05409"><area-name id="172"/></rom-file>
+                </category>
+                <category><name><region-name id="008"/></name>
+                    <category><name><area-name id="147"/></name>
+                        <rom-file id="05351"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="05352"><i18n-string id="Menu:MapN"/>2</rom-file>
+                    </category>
+                    <category><name><area-name id="197"/></name>
+                        <rom-file id="05447"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="05448"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="05528"><i18n-string id="Menu:MapN"/>3</rom-file>
+                        <rom-file id="05535"><i18n-string id="Menu:MapN"/>4</rom-file>
+                    </category>
+                    <rom-file id="05322"><area-name id="109"/></rom-file>
+                    <rom-file id="05354"><area-name id="148"/></rom-file>
+                    <rom-file id="05323"><area-name id="110"/></rom-file>
+                </category>
+                <category><name><region-name id="009"/></name>
+                    <rom-file id="05329"><area-name id="116"/></rom-file>
+                    <category><name><area-name id="145"/></name>
+                        <rom-file id="05348"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="05349"><i18n-string id="Menu:MapN"/>2</rom-file>
+                    </category>
+                    <category><name>Horutoto Ruins</name>
+                        <category><name>Amaryllis Tower</name>
+                            <rom-file id="05432"><i18n-string id="Menu:MapN"/>1</rom-file>
+                            <rom-file id="05467"><i18n-string id="Menu:MapN"/>2</rom-file>
+                            <rom-file id="05532"><i18n-string id="Menu:MapN"/>3</rom-file>
+                        </category>
+                        <rom-file id="05462">Beetle's Burrow</rom-file>
+                        <rom-file id="05436">Dahlia Tower</rom-file>
+                        <rom-file id="05433">Lilac Tower</rom-file>
+                        <rom-file id="05435">Lily Tower</rom-file>
+                        <rom-file id="05434">Marguerite Tower</rom-file>
+                        <category><name>Rose Tower</name>
+                            <rom-file id="05463"><i18n-string id="Menu:MapN"/>1</rom-file>
+                            <rom-file id="05466"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        </category>
+                    </category>
+                    <category><name><area-name id="169"/></name>
+                        <rom-file id="05406"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="05465"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="05633"><i18n-string id="Menu:MapN"/>3</rom-file>
+                    </category>
+                    <rom-file id="05328"><area-name id="115"/></rom-file>
+                </category>
+                <category><name><region-name id="010"/></name>
+                    <category><name><area-name id="004"/></name>
+                        <rom-file id="05690">Mainland</rom-file>
+                        <rom-file id="05691">Purgonorgo Isle</rom-file>
+                    </category>
+                    <rom-file id="05331"><area-name id="118"/></rom-file>
+                    <rom-file id="05679"><area-name id="213"/></rom-file>
+                    <rom-file id="05745"><area-name id="003"/></rom-file>
+                    <category><name><area-name id="198"/></name>
+                        <rom-file id="05449"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="05450"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="05536"><i18n-string id="Menu:MapN"/>3</rom-file>
+                    </category>
+                    <rom-file id="05498"><area-name id="249"/></rom-file>
+                    <rom-file id="05330"><area-name id="117"/></rom-file>
+                </category>
+                <category><name><region-name id="011"/></name>
+                    <rom-file id="05361"><area-name id="152"/></rom-file>
+                    <rom-file id="05693"><area-name id="007"/></rom-file>
+                    <category><name><area-name id="151"/></name>
+                        <rom-file id="05357"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="05358"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="05359"><i18n-string id="Menu:MapN"/>3</rom-file>
+                        <rom-file id="05360"><i18n-string id="Menu:MapN"/>4</rom-file>
+                        <rom-file id="05464"><i18n-string id="Menu:MapN"/>5</rom-file>
+                        <rom-file id="05468"><i18n-string id="Menu:MapN"/>6</rom-file>
+                        <rom-file id="05469"><i18n-string id="Menu:MapN"/>7</rom-file>
+                    </category>
+                    <category><name><area-name id="200"/></name>
+                        <rom-file id="05451"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="05459"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="05460"><i18n-string id="Menu:MapN"/>3</rom-file>
+                        <rom-file id="05461"><i18n-string id="Menu:MapN"/>4</rom-file>
+                        <rom-file id="05537"><i18n-string id="Menu:MapN"/>5</rom-file>
+                    </category>
+                    <rom-file id="05332"><area-name id="119"/></rom-file>
+                    <rom-file id="05333"><area-name id="120"/></rom-file>
+                </category>
+                <category><name><region-name id="012"/></name>
+                    <rom-file id="05324"><area-name id="111"/></rom-file>
+                    <category><name><area-name id="204"/></name>
+                        <rom-file id="05454"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="05455"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="05538"><i18n-string id="Menu:MapN"/>3</rom-file>
+                    </category>
+                    <category><name><area-name id="009"/></name>
+                        <rom-file id="05694"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="05695"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="05696"><i18n-string id="Menu:MapN"/>3</rom-file>
+                        <rom-file id="05697"><i18n-string id="Menu:MapN"/>4</rom-file>
+                        <rom-file id="05698"><i18n-string id="Menu:MapN"/>5</rom-file>
+                        <rom-file id="05699"><i18n-string id="Menu:MapN"/>6</rom-file>
+                        <rom-file id="05700"><i18n-string id="Menu:MapN"/>7</rom-file>
+                        <rom-file id="05701"><i18n-string id="Menu:MapN"/>8</rom-file>
+                        <rom-file id="05702"><i18n-string id="Menu:MapN"/>9</rom-file>
+                        <rom-file id="05703"><i18n-string id="Menu:MapN"/>10</rom-file>
+                        <rom-file id="05704"><i18n-string id="Menu:MapN"/>11</rom-file>
+                        <rom-file id="05705"><i18n-string id="Menu:MapN"/>12</rom-file>
+                        <rom-file id="05706"><i18n-string id="Menu:MapN"/>13</rom-file>
+                        <rom-file id="05707"><i18n-string id="Menu:MapN"/>14</rom-file>
+                        <rom-file id="05708"><i18n-string id="Menu:MapN"/>15</rom-file>
+                        <rom-file id="05709"><i18n-string id="Menu:MapN"/>16</rom-file>
+                    </category>
+                    <rom-file id="05400"><area-name id="166"/></rom-file>
+                </category>
+                <category><name><region-name id="013"/></name>
+                    <category><name><area-name id="161"/></name>
+                        <rom-file id="05390"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="05515"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="05516"><i18n-string id="Menu:MapN"/>3</rom-file>
+                        <rom-file id="05517"><i18n-string id="Menu:MapN"/>4</rom-file>
+                    </category>
+                    <category><name><area-name id="162"/></name>
+                        <rom-file id="05396"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="05397"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="05398"><i18n-string id="Menu:MapN"/>3</rom-file>
+                        <rom-file id="05399"><i18n-string id="Menu:MapN"/>4</rom-file>
+                        <rom-file id="05524"><i18n-string id="Menu:MapN"/>5</rom-file>
+                        <rom-file id="05525"><i18n-string id="Menu:MapN"/>6</rom-file>
+                        <rom-file id="05526"><i18n-string id="Menu:MapN"/>7</rom-file>
+                        <rom-file id="05527"><i18n-string id="Menu:MapN"/>8</rom-file>
+                    </category>
+                    <rom-file id="05692"><area-name id="005"/></rom-file>
+                    <rom-file id="05325"><area-name id="112"/></rom-file>
+                </category>
+                <category><name><region-name id="014"/></name>
+                    <rom-file id="05337"><area-name id="127"/></rom-file>
+                    <category><name>Delkfutt's Tower</name>
+                        <rom-file id="05385">Basement</rom-file>
+                        <rom-file id="05373">First Floor</rom-file>
+                        <rom-file id="05374">Second Floor</rom-file>
+                        <rom-file id="05375">Third Floor</rom-file>
+                        <rom-file id="05376">Fourth Floor</rom-file>
+                        <rom-file id="05377">Fifth Floor</rom-file>
+                        <rom-file id="05378">Sixth Floor</rom-file>
+                        <rom-file id="05379">Seventh Floor</rom-file>
+                        <rom-file id="05380">Eighth Floor</rom-file>
+                        <rom-file id="05381">Ninth Floor</rom-file>
+                        <rom-file id="05382">Tenth Floor</rom-file>
+                        <rom-file id="05383">Eleventh Floor</rom-file>
+                        <rom-file id="05384">Twelfth Floor</rom-file>
+                        <rom-file id="05518">Hidden Elevator 1</rom-file>
+                        <rom-file id="05519">Hidden Elevator 2</rom-file>
+                        <rom-file id="05520">Hidden Elevator 3</rom-file>
+                    </category>
+                    <rom-file id="05336"><area-name id="126"/></rom-file>
+                </category>
+            </category>
+            <category><name>&amp;<i18n-string id="FFXI2"/></name>
+                <category><name><region-name id="015"/></name>
+                    <rom-file id="05619"><area-name id="154"/></rom-file>
+                    <rom-file id="05683"><area-name id="251"/></rom-file>
+                    <rom-file id="05609"><area-name id="122"/></rom-file>
+                    <category><name><area-name id="153"/></name>
+                        <rom-file id="05615"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="05616"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="05617"><i18n-string id="Menu:MapN"/>3</rom-file>
+                        <rom-file id="05618"><i18n-string id="Menu:MapN"/>4</rom-file>
+                    </category>
+                    <rom-file id="05608"><area-name id="121"/></rom-file>
+                </category>
+                <category><name><region-name id="016"/></name>
+                    <rom-file id="05607"><area-name id="114"/></rom-file>
+                    <category><name><area-name id="208"/></name>
+                        <rom-file id="05671"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="05672"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="05673"><i18n-string id="Menu:MapN"/>3</rom-file>
+                        <rom-file id="05674"><i18n-string id="Menu:MapN"/>4</rom-file>
+                        <rom-file id="05675"><i18n-string id="Menu:MapN"/>5</rom-file>
+                        <rom-file id="05676"><i18n-string id="Menu:MapN"/>6</rom-file>
+                        <rom-file id="05686"><i18n-string id="Menu:MapN"/>7</rom-file>
+                        <rom-file id="05687"><i18n-string id="Menu:MapN"/>8</rom-file>
+                    </category>
+                    <rom-file id="05681"><area-name id="247"/></rom-file>
+                    <rom-file id="05612"><area-name id="125"/></rom-file>
+                </category>
+                <category><name><region-name id="017"/></name>
+                    <rom-file id="05606"><area-name id="113"/></rom-file>
+                    <category><name><area-name id="212"/></name>
+                        <rom-file id="05677"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="05678"><i18n-string id="Menu:MapN"/>2</rom-file>
+                    </category>
+                    <category><name><area-name id="174"/></name>
+                        <rom-file id="05411"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="05639"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="05640"><i18n-string id="Menu:MapN"/>3</rom-file>
+                        <rom-file id="05641"><i18n-string id="Menu:MapN"/>4</rom-file>
+                        <rom-file id="05642"><i18n-string id="Menu:MapN"/>5</rom-file>
+                    </category>
+                    <rom-file id="05613"><area-name id="128"/></rom-file>
+                </category>
+                <category><name><region-name id="018"/></name>
+                    <rom-file id="05682"><area-name id="250"/></rom-file>
+                    <rom-file id="05684"><area-name id="252"/></rom-file>
+                    <category><name><area-name id="176"/></name>
+                        <rom-file id="05643"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="05644"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="05645"><i18n-string id="Menu:MapN"/>3</rom-file>
+                        <rom-file id="05646"><i18n-string id="Menu:MapN"/>4</rom-file>
+                        <rom-file id="05647"><i18n-string id="Menu:MapN"/>5</rom-file>
+                    </category>
+                    <category><name>The Cavern Of Flames</name>
+                        <rom-file id="05456"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="05457"><i18n-string id="Menu:MapN"/>2</rom-file>
+                    </category>
+                    <rom-file id="05610"><area-name id="123"/></rom-file>
+                </category>
+                <category><name><region-name id="019"/></name>
+                    <category><name><area-name id="160"/></name>
+                        <rom-file id="05624"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="05625"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="05626"><i18n-string id="Menu:MapN"/>3</rom-file>
+                        <rom-file id="05627"><i18n-string id="Menu:MapN"/>4</rom-file>
+                        <rom-file id="05628"><i18n-string id="Menu:MapN"/>5</rom-file>
+                        <rom-file id="05629"><i18n-string id="Menu:MapN"/>6</rom-file>
+                        <rom-file id="05630"><i18n-string id="Menu:MapN"/>7</rom-file>
+                        <rom-file id="05631"><i18n-string id="Menu:MapN"/>8</rom-file>
+                        <rom-file id="05632"><i18n-string id="Menu:MapN"/>9</rom-file>
+                    </category>
+                    <category><name><area-name id="205"/></name>
+                        <rom-file id="05663"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="05664"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="05665"><i18n-string id="Menu:MapN"/>3</rom-file>
+                        <rom-file id="05666"><i18n-string id="Menu:MapN"/>4</rom-file>
+                        <rom-file id="05667"><i18n-string id="Menu:MapN"/>5</rom-file>
+                        <rom-file id="05668"><i18n-string id="Menu:MapN"/>6</rom-file>
+                        <rom-file id="05669"><i18n-string id="Menu:MapN"/>7</rom-file>
+                        <rom-file id="05670"><i18n-string id="Menu:MapN"/>8</rom-file>
+                        <rom-file id="05685"><i18n-string id="Menu:MapN"/>9</rom-file>
+                    </category>
+                    <category><name><area-name id="159"/></name>
+                        <rom-file id="05620"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="05621"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="05622"><i18n-string id="Menu:MapN"/>3</rom-file>
+                        <rom-file id="05623"><i18n-string id="Menu:MapN"/>4</rom-file>
+                    </category>
+                    <rom-file id="05611"><area-name id="124"/></rom-file>
+                </category>
+                <category><name><region-name id="020"/></name>
+                    <rom-file id="05614"><area-name id="130"/></rom-file>
+                    <category><name><area-name id="178"/></name>
+                        <rom-file id="05657"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="05658"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="05659"><i18n-string id="Menu:MapN"/>3</rom-file>
+                        <rom-file id="05660"><i18n-string id="Menu:MapN"/>4</rom-file>
+                        <rom-file id="05661"><i18n-string id="Menu:MapN"/>5</rom-file>
+                        <rom-file id="05662"><i18n-string id="Menu:MapN"/>6</rom-file>
+                    </category>
+                    <category><name><area-name id="177"/></name>
+                        <rom-file id="05648"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="05649"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="05650"><i18n-string id="Menu:MapN"/>3</rom-file>
+                        <rom-file id="05651"><i18n-string id="Menu:MapN"/>4</rom-file>
+                        <rom-file id="05652"><i18n-string id="Menu:MapN"/>5</rom-file>
+                        <rom-file id="05653"><i18n-string id="Menu:MapN"/>6</rom-file>
+                        <rom-file id="05654"><i18n-string id="Menu:MapN"/>7</rom-file>
+                        <rom-file id="05655"><i18n-string id="Menu:MapN"/>8</rom-file>
+                        <rom-file id="05656"><i18n-string id="Menu:MapN"/>9</rom-file>
+                    </category>
+                </category>
+                <category><name><region-name id="021"/></name></category>
+            </category>
+            <category><name>&amp;<i18n-string id="FFXI3"/></name>
+                <category><name><region-name id="022"/></name>
+                    <rom-file id="05710"><area-name id="011"/></rom-file>
+                    <rom-file id="05711"><area-name id="012"/></rom-file>
+                </category>
+                <category><name><region-name id="023"/></name>
+                    <category><name><area-name id="026"/></name>
+                        <rom-file id="05721"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="05722"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="05723"><i18n-string id="Menu:MapN"/>3</rom-file>
+                    </category>
+                </category>
+                <category><name><region-name id="024"/></name>
+                    <category><name><area-name id="044"/></name>
+                        <rom-file id="05747"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="05748"><i18n-string id="Menu:MapN"/>2</rom-file>
+                    </category>
+                    <rom-file id="05746"><area-name id="043"/></rom-file>
+                    <rom-file id="05719"><area-name id="024"/></rom-file>
+                    <rom-file id="05719"><area-name id="025"/></rom-file>
+                    <category><name><area-name id="027"/></name>
+                        <rom-file id="05724"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="05725"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="05739"><i18n-string id="Menu:MapN"/>3</rom-file>
+                    </category>
+                    <category><name><area-name id="030"/></name>
+                        <rom-file id="05730"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="05731"><i18n-string id="Menu:MapN"/>2</rom-file>
+                    </category>
+                    <category><name><area-name id="029"/></name>
+                        <rom-file id="05728"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="05729"><i18n-string id="Menu:MapN"/>2</rom-file>
+                    </category>
+                    <category><name><area-name id="028"/></name>
+                        <rom-file id="05726"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="05727"><i18n-string id="Menu:MapN"/>2</rom-file>
+                    </category>
+                    <rom-file id="05740"><area-name id="032"/></rom-file>
+                </category>
+                <category><name><region-name id="025"/></name>
+                    <rom-file id="05713"><area-name id="014"/> (<area-name id="018"/>?)</rom-file>
+                    <rom-file id="05712"><area-name id="014"/> (<area-name id="016"/>?)</rom-file>
+                    <rom-file id="05714"><area-name id="014"/> (<area-name id="020"/>?)</rom-file>
+                    <rom-file id="05716"><area-name id="018"/></rom-file>
+                    <rom-file id="05715"><area-name id="016"/></rom-file>
+                    <rom-file id="05717"><area-name id="020"/></rom-file>
+                    <rom-file id="05718"><area-name id="022"/></rom-file>
+                </category>
+                <category><name><region-name id="026"/></name>
+                    <rom-file id="05732"><area-name id="033"/></rom-file>
+                    <category><name><area-name id="034"/></name>
+                        <rom-file id="05733"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="05734"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="05741"><i18n-string id="Menu:MapN"/>3</rom-file>
+                    </category>
+                    <category><name><area-name id="035"/></name>
+                        <rom-file id="05735"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="05736"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="05737"><i18n-string id="Menu:MapN"/>3</rom-file>
+                        <rom-file id="05738"><i18n-string id="Menu:MapN"/>4</rom-file>
+                    </category>
+                </category>
+                <category><name><region-name id="027"/></name></category>
+            </category>
+            <category><name>&amp;<i18n-string id="FFXI4"/></name>
+                <category><name><region-name id="028"/></name></category>
+                <category><name><region-name id="029"/></name>
+                    <rom-file id="53298"><area-name id="050"/></rom-file>
+                    <rom-file id="53297"><area-name id="048"/></rom-file>
+                    <category><name><area-name id="052"/></name>
+                        <rom-file id="53300"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="53301"><i18n-string id="Menu:MapN"/>2</rom-file>
+                    </category>
+                    <category><name><area-name id="070"/></name>
+                        <rom-file id="53370"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="53371"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="53372"><i18n-string id="Menu:MapN"/>3</rom-file>
+                        <rom-file id="53373"><i18n-string id="Menu:MapN"/>4</rom-file>
+                        <rom-file id="53374"><i18n-string id="Menu:MapN"/>5</rom-file>
+                        <rom-file id="53375"><i18n-string id="Menu:MapN"/>6</rom-file>
+                        <rom-file id="53376"><i18n-string id="Menu:MapN"/>7</rom-file>
+                    </category>
+                    <category><name><area-name id="071"/></name>
+                        <rom-file id="53377"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="53378"><i18n-string id="Menu:MapN"/>2</rom-file>
+                    </category>
+                </category>
+                <category><name><region-name id="030"/></name>
+                    <category><name><area-name id="068"/></name>
+                        <rom-file id="53353"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="53354"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="53355"><i18n-string id="Menu:MapN"/>3</rom-file>
+                        <rom-file id="53356"><i18n-string id="Menu:MapN"/>4</rom-file>
+                        <rom-file id="53357"><i18n-string id="Menu:MapN"/>5</rom-file>
+                        <rom-file id="53358"><i18n-string id="Menu:MapN"/>6</rom-file>
+                        <rom-file id="53359"><i18n-string id="Menu:MapN"/>7</rom-file>
+                    </category>
+                    <category><name><area-name id="065"/></name>
+                        <rom-file id="53341"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="53342"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="53406"><i18n-string id="Menu:MapN"/>3</rom-file>
+                    </category>
+                    <category><name><area-name id="066"/></name>
+                        <rom-file id="53343"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="53344"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="53345"><i18n-string id="Menu:MapN"/>3</rom-file>
+                        <rom-file id="53346"><i18n-string id="Menu:MapN"/>4</rom-file>
+                        <rom-file id="53347"><i18n-string id="Menu:MapN"/>5</rom-file>
+                        <rom-file id="53348"><i18n-string id="Menu:MapN"/>6</rom-file>
+                        <rom-file id="53349"><i18n-string id="Menu:MapN"/>7</rom-file>
+                        <rom-file id="53350"><i18n-string id="Menu:MapN"/>8</rom-file>
+                        <rom-file id="53351"><i18n-string id="Menu:MapN"/>9</rom-file>
+                        <rom-file id="53352"><i18n-string id="Menu:MapN"/>10</rom-file>
+                    </category>
+                    <rom-file id="53299"><area-name id="051"/></rom-file>
+                </category>
+                <category><name><region-name id="031"/></name>
+                    <category><name><area-name id="062"/></name>
+                        <rom-file id="53329"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="53330"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="53407"><i18n-string id="Menu:MapN"/>3</rom-file>
+                        <rom-file id="53415"><i18n-string id="Menu:MapN"/>4</rom-file>
+                    </category>
+                    <category><name><area-name id="063"/></name>
+                        <rom-file id="53331"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="53332"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="53333"><i18n-string id="Menu:MapN"/>3</rom-file>
+                        <rom-file id="53334"><i18n-string id="Menu:MapN"/>4</rom-file>
+                        <rom-file id="53335"><i18n-string id="Menu:MapN"/>5</rom-file>
+                        <rom-file id="53336"><i18n-string id="Menu:MapN"/>6</rom-file>
+                        <rom-file id="53337"><i18n-string id="Menu:MapN"/>7</rom-file>
+                        <rom-file id="53338"><i18n-string id="Menu:MapN"/>8</rom-file>
+                        <rom-file id="53339"><i18n-string id="Menu:MapN"/>9</rom-file>
+                        <rom-file id="53340"><i18n-string id="Menu:MapN"/>10</rom-file>
+                    </category>
+                    <rom-file id="53328"><area-name id="061"/></rom-file>
+                </category>
+                <category><name><region-name id="032"/></name>
+                    <category><name><area-name id="054"/></name>
+                        <rom-file id="53303"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="53304"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="53305"><i18n-string id="Menu:MapN"/>3</rom-file>
+                        <rom-file id="53398"><i18n-string id="Menu:MapN"/>4</rom-file>
+                        <rom-file id="53399"><i18n-string id="Menu:MapN"/>5</rom-file>
+                        <rom-file id="53400"><i18n-string id="Menu:MapN"/>6</rom-file>
+                        <rom-file id="53401"><i18n-string id="Menu:MapN"/>7</rom-file>
+                        <rom-file id="53402"><i18n-string id="Menu:MapN"/>8</rom-file>
+                        <rom-file id="53403"><i18n-string id="Menu:MapN"/>9</rom-file>
+                        <rom-file id="53404"><i18n-string id="Menu:MapN"/>10</rom-file>
+                        <rom-file id="53405"><i18n-string id="Menu:MapN"/>11</rom-file>
+                    </category>
+                    <category><name><area-name id="079"/></name>
+                        <rom-file id="53394"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="53395"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="53396"><i18n-string id="Menu:MapN"/>3</rom-file>
+                        <rom-file id="53397"><i18n-string id="Menu:MapN"/>4</rom-file>
+                    </category>
+                    <category><name><area-name id="055"/></name>
+                        <rom-file id="53306"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="53307"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="53308"><i18n-string id="Menu:MapN"/>3</rom-file>
+                        <rom-file id="53309"><i18n-string id="Menu:MapN"/>4</rom-file>
+                        <rom-file id="53310"><i18n-string id="Menu:MapN"/>5</rom-file>
+                        <rom-file id="53311"><i18n-string id="Menu:MapN"/>6</rom-file>
+                        <rom-file id="53312"><i18n-string id="Menu:MapN"/>7</rom-file>
+                        <rom-file id="53313"><i18n-string id="Menu:MapN"/>8</rom-file>
+                        <rom-file id="53314"><i18n-string id="Menu:MapN"/>9</rom-file>
+                        <rom-file id="53315"><i18n-string id="Menu:MapN"/>10</rom-file>
+                    </category>
+                    <category><name><area-name id="069"/></name>
+                        <rom-file id="53360"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="53361"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="53362"><i18n-string id="Menu:MapN"/>3</rom-file>
+                        <rom-file id="53363"><i18n-string id="Menu:MapN"/>4</rom-file>
+                        <rom-file id="53364"><i18n-string id="Menu:MapN"/>5</rom-file>
+                        <rom-file id="53365"><i18n-string id="Menu:MapN"/>6</rom-file>
+                        <rom-file id="53366"><i18n-string id="Menu:MapN"/>7</rom-file>
+                        <rom-file id="53367"><i18n-string id="Menu:MapN"/>8</rom-file>
+                        <rom-file id="53368"><i18n-string id="Menu:MapN"/>9</rom-file>
+                        <rom-file id="53369"><i18n-string id="Menu:MapN"/>10</rom-file>
+                    </category>
+                    <rom-file id="53302"><area-name id="053"/></rom-file>
+                    <category><name><area-name id="077"/></name>
+                        <rom-file id="53384"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="53385"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="53386"><i18n-string id="Menu:MapN"/>3</rom-file>
+                        <rom-file id="53387"><i18n-string id="Menu:MapN"/>4</rom-file>
+                        <rom-file id="53388"><i18n-string id="Menu:MapN"/>5</rom-file>
+                        <rom-file id="53389"><i18n-string id="Menu:MapN"/>6</rom-file>
+                        <rom-file id="53390"><i18n-string id="Menu:MapN"/>7</rom-file>
+                        <rom-file id="53391"><i18n-string id="Menu:MapN"/>8</rom-file>
+                    </category>
+                    <category><name><area-name id="056"/></name>
+                        <rom-file id="53316"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="53317"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="53318"><i18n-string id="Menu:MapN"/>3</rom-file>
+                        <rom-file id="53319"><i18n-string id="Menu:MapN"/>4</rom-file>
+                        <rom-file id="53320"><i18n-string id="Menu:MapN"/>5</rom-file>
+                        <rom-file id="53321"><i18n-string id="Menu:MapN"/>6</rom-file>
+                        <rom-file id="53322"><i18n-string id="Menu:MapN"/>7</rom-file>
+                        <rom-file id="53323"><i18n-string id="Menu:MapN"/>8</rom-file>
+                        <rom-file id="53324"><i18n-string id="Menu:MapN"/>9</rom-file>
+                        <rom-file id="53325"><i18n-string id="Menu:MapN"/>10</rom-file>
+                    </category>
+                </category>
+                <category><name><region-name id="033"/></name>
+                    <category><name><area-name id="072"/></name>
+                        <rom-file id="53379"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="53380"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="53381"><i18n-string id="Menu:MapN"/>3</rom-file>
+                        <rom-file id="53382"><i18n-string id="Menu:MapN"/>4</rom-file>
+                        <rom-file id="53383"><i18n-string id="Menu:MapN"/>5</rom-file>
+                        <rom-file id="53408"><i18n-string id="Menu:MapN"/>6</rom-file>
+                        <rom-file id="53409"><i18n-string id="Menu:MapN"/>7</rom-file>
+                        <rom-file id="53410"><i18n-string id="Menu:MapN"/>8</rom-file>
+                        <rom-file id="53411"><i18n-string id="Menu:MapN"/>9</rom-file>
+                        <rom-file id="53412"><i18n-string id="Menu:MapN"/>10</rom-file>
+                        <rom-file id="53413"><i18n-string id="Menu:MapN"/>11</rom-file>
+                        <rom-file id="53414"><i18n-string id="Menu:MapN"/>12</rom-file>
+                    </category>
+                    <category><name><area-name id="074"/></name>
+                        <rom-file id="53424"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="53425"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="53426"><i18n-string id="Menu:MapN"/>3</rom-file>
+                        <rom-file id="53427"><i18n-string id="Menu:MapN"/>4</rom-file>
+                        <rom-file id="53428"><i18n-string id="Menu:MapN"/>5</rom-file>
+                        <rom-file id="53429"><i18n-string id="Menu:MapN"/>6</rom-file>
+                        <rom-file id="53430"><i18n-string id="Menu:MapN"/>7</rom-file>
+                    </category>
+                    <category><name><area-name id="075"/></name>
+                        <rom-file id="53431"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="53432"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="53433"><i18n-string id="Menu:MapN"/>3</rom-file>
+                        <rom-file id="53434"><i18n-string id="Menu:MapN"/>4</rom-file>
+                        <rom-file id="53435"><i18n-string id="Menu:MapN"/>5</rom-file>
+                    </category>
+                    <category><name><area-name id="076"/></name>
+                        <rom-file id="53436"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="53437"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="53438"><i18n-string id="Menu:MapN"/>3</rom-file>
+                        <rom-file id="53439"><i18n-string id="Menu:MapN"/>4</rom-file>
+                        <rom-file id="53440"><i18n-string id="Menu:MapN"/>5</rom-file>
+                    </category>
+                    <category><name><area-name id="073"/></name>
+                        <rom-file id="53417"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="53418"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="53419"><i18n-string id="Menu:MapN"/>3</rom-file>
+                        <rom-file id="53420"><i18n-string id="Menu:MapN"/>4</rom-file>
+                        <rom-file id="53421"><i18n-string id="Menu:MapN"/>5</rom-file>
+                        <rom-file id="53422"><i18n-string id="Menu:MapN"/>6</rom-file>
+                        <rom-file id="53423"><i18n-string id="Menu:MapN"/>7</rom-file>
+                    </category>
+                </category>
+            </category>
+            <category><name>&amp;<i18n-string id="FFXI5"/></name>
+                <category><name><region-name id="034"/></name></category>
+                <category><name><region-name id="035"/></name></category>
+                <category><name><region-name id="036"/></name></category>
+                <category><name><region-name id="037"/></name></category>
+                <category><name><region-name id="038"/></name></category>
+                <category><name><region-name id="039"/></name></category>
+                <category><name><region-name id="040"/></name></category>
+                <category><name><region-name id="041"/></name></category>
+                <category><name><region-name id="042"/></name></category>
+                <category><name><region-name id="043"/></name></category>
+                <category><name><region-name id="044"/></name></category>
+                <category><name><region-name id="045"/></name></category>
+                <category><name><area-name id="086"/></name>
+                    <rom-file id="53496"><i18n-string id="Menu:MapN"/>1</rom-file>
+                    <rom-file id="53497"><i18n-string id="Menu:MapN"/>2</rom-file>
+                    <rom-file id="53498"><i18n-string id="Menu:MapN"/>3</rom-file>
+                    <rom-file id="53499"><i18n-string id="Menu:MapN"/>4</rom-file>
+                    <rom-file id="53500"><i18n-string id="Menu:MapN"/>5</rom-file>
+                    <rom-file id="53501"><i18n-string id="Menu:MapN"/>6</rom-file>
+                    <rom-file id="53502"><i18n-string id="Menu:MapN"/>7</rom-file>
+                    <rom-file id="53503"><i18n-string id="Menu:MapN"/>8</rom-file>
+                    <rom-file id="53504"><i18n-string id="Menu:MapN"/>9</rom-file>
+                    <rom-file id="53505"><i18n-string id="Menu:MapN"/>10</rom-file>
+                    <rom-file id="53506"><i18n-string id="Menu:MapN"/>11</rom-file>
+                    <rom-file id="53507"><i18n-string id="Menu:MapN"/>12</rom-file>
+                    <rom-file id="53508"><i18n-string id="Menu:MapN"/>13</rom-file>
+                    <rom-file id="53509"><i18n-string id="Menu:MapN"/>14</rom-file>
+                    <rom-file id="53510"><i18n-string id="Menu:MapN"/>15</rom-file>
+                    <rom-file id="53511"><i18n-string id="Menu:MapN"/>16</rom-file>
+                    <rom-file id="53512"><i18n-string id="Menu:MapN"/>17</rom-file>
+                    <rom-file id="53513"><i18n-string id="Menu:MapN"/>18</rom-file>
+                </category>
+                <category><name><area-name id="093"/></name>
+                    <rom-file id="53514"><i18n-string id="Menu:MapN"/>1</rom-file>
+                    <rom-file id="53515"><i18n-string id="Menu:MapN"/>2</rom-file>
+                    <rom-file id="53516"><i18n-string id="Menu:MapN"/>3</rom-file>
+                    <rom-file id="53517"><i18n-string id="Menu:MapN"/>4</rom-file>
+                    <rom-file id="53518"><i18n-string id="Menu:MapN"/>5</rom-file>
+                    <rom-file id="53519"><i18n-string id="Menu:MapN"/>6</rom-file>
+                    <rom-file id="53520"><i18n-string id="Menu:MapN"/>7</rom-file>
+                    <rom-file id="53521"><i18n-string id="Menu:MapN"/>8</rom-file>
+                    <rom-file id="53522"><i18n-string id="Menu:MapN"/>9</rom-file>
+                    <rom-file id="53523"><i18n-string id="Menu:MapN"/>10</rom-file>
+                    <rom-file id="53524"><i18n-string id="Menu:MapN"/>11</rom-file>
+                    <rom-file id="53525"><i18n-string id="Menu:MapN"/>12</rom-file>
+                    <rom-file id="53526"><i18n-string id="Menu:MapN"/>13</rom-file>
+                    <rom-file id="53527"><i18n-string id="Menu:MapN"/>14</rom-file>
+                    <rom-file id="53528"><i18n-string id="Menu:MapN"/>15</rom-file>
+                    <rom-file id="53529"><i18n-string id="Menu:MapN"/>16</rom-file>
+                </category>
+                <category><name><area-name id="129"/></name>
+                    <rom-file id="53530"><i18n-string id="Menu:MapN"/>1</rom-file>
+                    <rom-file id="53531"><i18n-string id="Menu:MapN"/>2</rom-file>
+                    <rom-file id="53532"><i18n-string id="Menu:MapN"/>3</rom-file>
+                    <rom-file id="53533"><i18n-string id="Menu:MapN"/>4</rom-file>
+                    <rom-file id="53534"><i18n-string id="Menu:MapN"/>5</rom-file>
+                    <rom-file id="53535"><i18n-string id="Menu:MapN"/>6</rom-file>
+                    <rom-file id="53536"><i18n-string id="Menu:MapN"/>7</rom-file>
+                    <rom-file id="53537"><i18n-string id="Menu:MapN"/>8</rom-file>
+                    <rom-file id="53538"><i18n-string id="Menu:MapN"/>9</rom-file>
+                    <rom-file id="53539"><i18n-string id="Menu:MapN"/>10</rom-file>
+                    <rom-file id="53540"><i18n-string id="Menu:MapN"/>11</rom-file>
+                    <rom-file id="53541"><i18n-string id="Menu:MapN"/>12</rom-file>
+                    <rom-file id="53542"><i18n-string id="Menu:MapN"/>13</rom-file>
+                    <rom-file id="53543"><i18n-string id="Menu:MapN"/>14</rom-file>
+                    <rom-file id="53544"><i18n-string id="Menu:MapN"/>15</rom-file>
+                    <rom-file id="53545"><i18n-string id="Menu:MapN"/>16</rom-file>
+                    <rom-file id="53546"><i18n-string id="Menu:MapN"/>17</rom-file>
+                    <rom-file id="53547"><i18n-string id="Menu:MapN"/>18</rom-file>
+                </category>
+            </category>
+            <category><name><i18n-string id="FFXI9"/></name>
+                <category><name><region-name id="049"/></name>
+                    <rom-file id="53570"><area-name id="256"/></rom-file>
+                    <rom-file id="53571"><area-name id="257"/></rom-file>
+                    <rom-file id="53572"><area-name id="258"/></rom-file>
+                    <category><name><area-name id="259"/></name>
+                        <rom-file id="53573"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="53574"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="53575"><i18n-string id="Menu:MapN"/>3</rom-file>
+                        <rom-file id="53576"><i18n-string id="Menu:MapN"/>4</rom-file>
+                        <rom-file id="53577"><i18n-string id="Menu:MapN"/>5</rom-file>
+                        <rom-file id="53578"><i18n-string id="Menu:MapN"/>6</rom-file>
+                        <rom-file id="53579"><i18n-string id="Menu:MapN"/>7</rom-file>
+                        <rom-file id="53580"><i18n-string id="Menu:MapN"/>8</rom-file>
+                        <rom-file id="53581"><i18n-string id="Menu:MapN"/>9</rom-file>
+                        <rom-file id="53582"><i18n-string id="Menu:MapN"/>10</rom-file>
+                        <rom-file id="53583"><i18n-string id="Menu:MapN"/>11</rom-file>
+                        <rom-file id="53584"><i18n-string id="Menu:MapN"/>12</rom-file>
+                        <rom-file id="53585"><i18n-string id="Menu:MapN"/>13</rom-file>
+                        <rom-file id="53586"><i18n-string id="Menu:MapN"/>14</rom-file>
+                        <rom-file id="53587"><i18n-string id="Menu:MapN"/>15</rom-file>
+                    </category>
+                </category>
+                <category><name><region-name id="050"/></name>
+                    <rom-file id="53588"><area-name id="260"/></rom-file>
+                    <rom-file id="53589"><area-name id="261"/></rom-file>
+                    <rom-file id="53590"><area-name id="262"/></rom-file>
+                    <rom-file id="53591"><area-name id="265"/></rom-file>
+                    <category><name><area-name id="268"/></name>
+                        <rom-file id="53592"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="53593"><i18n-string id="Menu:MapN"/>2</rom-file>
+                    </category>
+                    <category><name><area-name id="269"/></name>
+                        <rom-file id="53594"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="53595"><i18n-string id="Menu:MapN"/>2</rom-file>
+                    </category>
+                    <rom-file id="53596"><area-name id="270"/></rom-file>
+                    <category><name><area-name id="271"/></name>
+                        <rom-file id="53597"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="53598"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="53599"><i18n-string id="Menu:MapN"/>3</rom-file>
+                        <rom-file id="53600"><i18n-string id="Menu:MapN"/>4</rom-file>
+                        <rom-file id="53601"><i18n-string id="Menu:MapN"/>5</rom-file>
+                        <rom-file id="53602"><i18n-string id="Menu:MapN"/>6</rom-file>
+                        <rom-file id="53603"><i18n-string id="Menu:MapN"/>7</rom-file>
+                        <rom-file id="53604"><i18n-string id="Menu:MapN"/>8</rom-file>
+                        <rom-file id="53605"><i18n-string id="Menu:MapN"/>9</rom-file>
+                        <rom-file id="53606"><i18n-string id="Menu:MapN"/>10</rom-file>
+                        <rom-file id="53607"><i18n-string id="Menu:MapN"/>11</rom-file>
+                        <rom-file id="53608"><i18n-string id="Menu:MapN"/>12</rom-file>
+                        <rom-file id="53609"><i18n-string id="Menu:MapN"/>13</rom-file>
+                        <rom-file id="53610"><i18n-string id="Menu:MapN"/>14</rom-file>
+                        <rom-file id="53611"><i18n-string id="Menu:MapN"/>15</rom-file>
+                        <rom-file id="53612"><i18n-string id="Menu:MapN"/>16</rom-file>
+                        <rom-file id="53613"><i18n-string id="Menu:MapN"/>17</rom-file>
+                        <rom-file id="53614"><i18n-string id="Menu:MapN"/>18</rom-file>
+                        <rom-file id="53615"><i18n-string id="Menu:MapN"/>19</rom-file>
+                    </category>
+                    <rom-file id="53616"><area-name id="263"/></rom-file>
+                    <category><name><area-name id="264"/></name>
+                        <rom-file id="53617"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="53618"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="53619"><i18n-string id="Menu:MapN"/>3</rom-file>
+                        <rom-file id="53620"><i18n-string id="Menu:MapN"/>4</rom-file>
+                        <rom-file id="53621"><i18n-string id="Menu:MapN"/>5</rom-file>
+                        <rom-file id="53622"><i18n-string id="Menu:MapN"/>6</rom-file>
+                        <rom-file id="53623"><i18n-string id="Menu:MapN"/>7</rom-file>
+                        <rom-file id="53624"><i18n-string id="Menu:MapN"/>8</rom-file>
+                        <rom-file id="53625"><i18n-string id="Menu:MapN"/>9</rom-file>
+                        <rom-file id="53626"><i18n-string id="Menu:MapN"/>10</rom-file>
+                        <rom-file id="53627"><i18n-string id="Menu:MapN"/>11</rom-file>
+                    </category>
+                    <rom-file id="53628"><area-name id="266"/></rom-file>
+                    <category><name><area-name id="272"/></name>
+                        <rom-file id="53629"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="53630"><i18n-string id="Menu:MapN"/>2</rom-file>
+                    </category>
+                    <rom-file id="53631"><area-name id="267"/></rom-file>
+                    <category><name><area-name id="273"/></name>
+                        <rom-file id="53632"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="53633"><i18n-string id="Menu:MapN"/>2</rom-file>
+                    </category>
+                    <category><name><area-name id="274"/></name>
+                        <rom-file id="53635"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="53636"><i18n-string id="Menu:MapN"/>2</rom-file>
+                    </category>
+                    <category><name><area-name id="275"/></name>
+                        <rom-file id="53637"><i18n-string id="Menu:MapN"/>1</rom-file>
+                        <rom-file id="53638"><i18n-string id="Menu:MapN"/>2</rom-file>
+                        <rom-file id="53639"><i18n-string id="Menu:MapN"/>3</rom-file>
+                        <rom-file id="53640"><i18n-string id="Menu:MapN"/>4</rom-file>
+                        <rom-file id="53641"><i18n-string id="Menu:MapN"/>5</rom-file>
+                        <rom-file id="53642"><i18n-string id="Menu:MapN"/>6</rom-file>
+                        <rom-file id="53643"><i18n-string id="Menu:MapN"/>7</rom-file>
+                        <rom-file id="53644"><i18n-string id="Menu:MapN"/>8</rom-file>
+                        <rom-file id="53645"><i18n-string id="Menu:MapN"/>9</rom-file>
+                        <rom-file id="53646"><i18n-string id="Menu:MapN"/>10</rom-file>
+                        <rom-file id="53647"><i18n-string id="Menu:MapN"/>11</rom-file>
+                        <rom-file id="53648"><i18n-string id="Menu:MapN"/>12</rom-file>
+                        <rom-file id="53649"><i18n-string id="Menu:MapN"/>13</rom-file>
+                        <rom-file id="53650"><i18n-string id="Menu:MapN"/>14</rom-file>
+                        <rom-file id="53651"><i18n-string id="Menu:MapN"/>15</rom-file>
+                        <rom-file id="53652"><i18n-string id="Menu:MapN"/>16</rom-file>
+                    </category>
+                </category>
+            </category>
+            <category><name><i18n-string id="Menu:Abyssea"/></name>
+                <rom-file id="53548"><area-name id="015"/></rom-file>
+                <rom-file id="53549"><area-name id="045"/></rom-file>
+                <rom-file id="53550"><area-name id="132"/></rom-file>
+                <rom-file id="53551"><area-name id="215"/></rom-file>
+                <rom-file id="53552"><area-name id="216"/></rom-file>
+                <rom-file id="53553"><area-name id="217"/></rom-file>
+                <rom-file id="53554"><area-name id="218"/></rom-file>
+                <rom-file id="53555"><area-name id="253"/></rom-file>
+                <rom-file id="53556"><area-name id="254"/></rom-file>
+            </category>
+            <category><name><i18n-string id="Menu:Dynamis"/></name>
+                <rom-file id="53557"><area-name id="185"/></rom-file>
+                <rom-file id="53558"><area-name id="186"/></rom-file>
+                <rom-file id="53559"><area-name id="187"/></rom-file>
+                <rom-file id="53560"><area-name id="188"/></rom-file>
+                <rom-file id="53561"><area-name id="134"/></rom-file>
+                <rom-file id="53562"><area-name id="135"/></rom-file>
+                <rom-file id="53563"><area-name id="039"/></rom-file>
+                <rom-file id="53564"><area-name id="040"/></rom-file>
+                <rom-file id="53565"><area-name id="041"/></rom-file>
+                <category><name><area-name id="042"/></name>
+                    <rom-file id="53566"><i18n-string id="Menu:MapN"/>1</rom-file>
+                    <rom-file id="53567"><i18n-string id="Menu:MapN"/>2</rom-file>
+                    <rom-file id="53568"><i18n-string id="Menu:MapN"/>3</rom-file>
+                </category>
+            </category>
+            <category><name><i18n-string id="Menu:Other"/></name>
+                <rom-file id="53416">Besieged Map</rom-file>
+                <rom-file id="05312">Conquest Map</rom-file>
+                <rom-file id="05541">Creature Chart</rom-file>
+                <!-- Also: 0/17/38,45,46,49,64,75-82,97-100,102-106,115,116,118,119,123-127 and 0/18/0-7,35,36,58,73,82,83 -->
+                <rom-file id="05326">Dummy Map</rom-file>
+                <rom-file id="05540">Element Chart</rom-file>
+                <!-- Also: 0/17/61,73,74; 0/18/41,105,106; 3/4/44,45 -->
+                <rom-file id="05339">No Map</rom-file>
+                <!-- Also: 0/17/83 -->
+                <rom-file id="05347">No Map (Alternate)</rom-file>
+                <rom-file id="05539">Stellar Map</rom-file>
+                <category><name><i18n-string id="Menu:TransportRoutes"/></name>
+                    <rom-file id="05473"><area-name id="224"/></rom-file>
+                    <rom-file id="05680"><area-name id="226"/></rom-file>
+                    <rom-file id="05472"><area-name id="223"/></rom-file>
+                    <rom-file id="05474"><area-name id="225"/></rom-file>
+                    <separator/>
+                    <rom-file id="05471"><area-name id="220"/></rom-file>
+                    <rom-file id="05470"><area-name id="221"/></rom-file>
+                    <separator/>
+                    <rom-file id="53295"><area-name id="046"/></rom-file>
+                    <rom-file id="53296"><area-name id="047"/></rom-file>
+                    <rom-file id="53326"><area-name id="058"/></rom-file>
+                    <rom-file id="53327"><area-name id="059"/></rom-file>
+                </category>
+            </category>
+        </category>
+        <category><name><i18n-string id="Menu:Other"/></name>
+            <rom-file id="00001"><i18n-string id="Menu:FontsAndMenus"/></rom-file>
+            <rom-file id="05112"><i18n-string id="Menu:RankBastok"/></rom-file><!-- alternative file IDs: 5113 -->
+            <rom-file id="05128"><i18n-string id="Menu:RankWindurst"/></rom-file>
+            <rom-file id="05144"><i18n-string id="Menu:RankSandOria"/></rom-file>
+            <category><name><i18n-string id="Menu:UIWindows"/></name>
+                <rom-file id="00014"><i18n-string id="Menu:StyleN"/>1</rom-file>
+                <rom-file id="00015"><i18n-string id="Menu:StyleN"/>2</rom-file>
+                <rom-file id="00016"><i18n-string id="Menu:StyleN"/>3</rom-file>
+                <rom-file id="00017"><i18n-string id="Menu:StyleN"/>4</rom-file>
+                <rom-file id="00018"><i18n-string id="Menu:StyleN"/>5</rom-file>
+                <rom-file id="00019"><i18n-string id="Menu:StyleN"/>6</rom-file>
+                <rom-file id="00020"><i18n-string id="Menu:StyleN"/>7</rom-file>
+                <rom-file id="00021"><i18n-string id="Menu:StyleN"/>8</rom-file>
+            </category>
+        </category>
     </category>
-    <!-- German: 55865-56120 -->
-    <category><name><i18n-string id="Menu:German"/></name>
-      <category><name>&amp;<i18n-string id="FFXI1"/></name>
-	<category><name><region-name id="000"/></name>
-	  <rom-file id="56098"><area-name id="233"/></rom-file>
-	  <rom-file id="56096"><area-name id="231"/></rom-file>
-	  <rom-file id="56097"><area-name id="232"/></rom-file>
-	  <rom-file id="56095"><area-name id="230"/></rom-file>
-	</category>
-	<category><name><region-name id="001"/></name>
-	  <rom-file id="56100"><area-name id="235"/></rom-file>
-	  <rom-file id="56099"><area-name id="234"/></rom-file>
-	  <rom-file id="56102"><area-name id="237"/></rom-file>
-	  <rom-file id="56101"><area-name id="236"/></rom-file>
-	</category>
-	<category><name><region-name id="002"/></name>
-	  <rom-file id="56107"><area-name id="242"/></rom-file>
-	  <rom-file id="56105"><area-name id="240"/></rom-file>
-	  <rom-file id="56104"><area-name id="239"/></rom-file>
-	  <rom-file id="56103"><area-name id="238"/></rom-file>
-	  <rom-file id="56106"><area-name id="241"/></rom-file>
-	</category>
-	<category><name><region-name id="003"/></name>
-	  <rom-file id="56110"><area-name id="245"/></rom-file>
-	  <rom-file id="56111"><area-name id="246"/></rom-file>
-	  <rom-file id="56108"><area-name id="243"/></rom-file>
-	  <rom-file id="56109"><area-name id="244"/></rom-file>
-	</category>
-	<category><name><region-name id="004"/></name>
-	  <rom-file id="56032"><area-name id="167"/></rom-file>
-	  <rom-file id="55966"><area-name id="101"/></rom-file>
-	  <rom-file id="56006"><area-name id="141"/></rom-file>
-	  <rom-file id="56005"><area-name id="140"/></rom-file>
-	  <rom-file id="56004"><area-name id="139"/></rom-file>
-	  <rom-file id="56055"><area-name id="190"/></rom-file>
-	  <rom-file id="55965"><area-name id="100"/></rom-file>
-	  <rom-file id="56007"><area-name id="142"/></rom-file>
-	</category>
-	<category><name><region-name id="005"/></name>
-	  <rom-file id="56061"><area-name id="196"/></rom-file>
-	  <rom-file id="55973"><area-name id="108"/></rom-file>
-	  <rom-file id="55967"><area-name id="102"/></rom-file>
-	  <rom-file id="56058"><area-name id="193"/></rom-file>
-	  <rom-file id="56113"><area-name id="248"/></rom-file>
-	  <rom-file id="55968"><area-name id="103"/></rom-file>
-	</category>
-	<category><name><region-name id="006"/></name>
-	  <rom-file id="55970"><area-name id="105"/></rom-file>
-	  <rom-file id="55867"><area-name id="002"/></rom-file>
-	  <rom-file id="56014"><area-name id="149"/></rom-file>
-	  <rom-file id="55969"><area-name id="104"/></rom-file>
-	  <rom-file id="56015"><area-name id="150"/></rom-file>
-	  <rom-file id="55866"><area-name id="001"/></rom-file>
-	  <rom-file id="56060"><area-name id="195"/></rom-file>
-	</category>
-	<category><name><region-name id="007"/></name>
-	  <rom-file id="56056"><area-name id="191"/></rom-file>
-	  <rom-file id="56038"><area-name id="173"/></rom-file>
-	  <rom-file id="55971"><area-name id="106"/></rom-file>
-	  <rom-file id="56008"><area-name id="143"/></rom-file>
-	  <rom-file id="55972"><area-name id="107"/></rom-file>
-	  <rom-file id="56009"><area-name id="144"/></rom-file>
-	  <rom-file id="56037"><area-name id="172"/></rom-file>
-	</category>
-	<category><name><region-name id="008"/></name>
-	  <rom-file id="56012"><area-name id="147"/></rom-file>
-	  <rom-file id="56062"><area-name id="197"/></rom-file>
-	  <rom-file id="55974"><area-name id="109"/></rom-file>
-	  <rom-file id="56013"><area-name id="148"/></rom-file>
-	  <rom-file id="55975"><area-name id="110"/></rom-file>
-	</category>
-	<category><name><region-name id="009"/></name>
-	  <rom-file id="56011"><area-name id="146"/></rom-file>
-	  <rom-file id="55981"><area-name id="116"/></rom-file>
-	  <rom-file id="56035"><area-name id="170"/></rom-file>
-	  <rom-file id="56010"><area-name id="145"/></rom-file>
-	  <rom-file id="56057"><area-name id="192"/></rom-file>
-	  <rom-file id="56059"><area-name id="194"/></rom-file>
-	  <rom-file id="56034"><area-name id="169"/></rom-file>
-	  <rom-file id="55980"><area-name id="115"/></rom-file>
-	</category>
-	<category><name><region-name id="010"/></name>
-	  <rom-file id="55869"><area-name id="004"/></rom-file>
-	  <rom-file id="55983"><area-name id="118"/></rom-file>
-	  <rom-file id="56078"><area-name id="213"/></rom-file>
-	  <rom-file id="55868"><area-name id="003"/></rom-file>
-	  <rom-file id="56063"><area-name id="198"/></rom-file>
-	  <rom-file id="56114"><area-name id="249"/></rom-file>
-	  <rom-file id="55982"><area-name id="117"/></rom-file>
-	</category>
-	<category><name><region-name id="011"/></name>
-	  <rom-file id="56017"><area-name id="152"/></rom-file>
-	  <rom-file id="55872"><area-name id="007"/></rom-file>
-	  <rom-file id="55873"><area-name id="008"/></rom-file>
-	  <rom-file id="56016"><area-name id="151"/></rom-file>
-	  <rom-file id="56065"><area-name id="200"/></rom-file>
-	  <rom-file id="55984"><area-name id="119"/></rom-file>
-	  <rom-file id="55985"><area-name id="120"/></rom-file>
-	</category>
-	<category><name><region-name id="012"/></name>
-	  <rom-file id="55976"><area-name id="111"/></rom-file>
-	  <rom-file id="56068"><area-name id="203"/></rom-file>
-	  <rom-file id="56069"><area-name id="204"/></rom-file>
-	  <rom-file id="55874"><area-name id="009"/></rom-file>
-	  <rom-file id="56071"><area-name id="206"/></rom-file>
-	  <rom-file id="56031"><area-name id="166"/></rom-file>
-	  <rom-file id="55875"><area-name id="010"/></rom-file>
-	</category>
-	<category><name><region-name id="013"/></name>
-	  <rom-file id="55871"><area-name id="006"/></rom-file>
-	  <rom-file id="56026"><area-name id="161"/></rom-file>
-	  <rom-file id="56027"><area-name id="162"/></rom-file>
-	  <rom-file id="56030"><area-name id="165"/></rom-file>
-	  <rom-file id="55870"><area-name id="005"/></rom-file>
-	  <rom-file id="55977"><area-name id="112"/></rom-file>
-	</category>
-	<category><name><region-name id="014"/></name>
-	  <rom-file id="55992"><area-name id="127"/></rom-file>
-	  <rom-file id="56049"><area-name id="184"/></rom-file>
-	  <rom-file id="56022"><area-name id="157"/></rom-file>
-	  <rom-file id="55996"><area-name id="131"/></rom-file>
-	  <rom-file id="55991"><area-name id="126"/></rom-file>
-	  <rom-file id="56044"><area-name id="179"/></rom-file>
-	  <rom-file id="56023"><area-name id="158"/></rom-file>
-	</category>
-      </category>
-      <category><name>&amp;<i18n-string id="FFXI2"/></name>
-	<category><name><region-name id="015"/></name>
-	  <rom-file id="56067"><area-name id="202"/></rom-file>
-	  <rom-file id="56019"><area-name id="154"/></rom-file>
-	  <rom-file id="56116"><area-name id="251"/></rom-file>
-	  <rom-file id="55987"><area-name id="122"/></rom-file>
-	  <rom-file id="56018"><area-name id="153"/></rom-file>
-	  <rom-file id="55986"><area-name id="121"/></rom-file>
-	</category>
-	<category><name><region-name id="016"/></name>
-	  <rom-file id="56033"><area-name id="168"/></rom-file>
-	  <rom-file id="56074"><area-name id="209"/></rom-file>
-	  <rom-file id="55979"><area-name id="114"/></rom-file>
-	  <rom-file id="56073"><area-name id="208"/></rom-file>
-	  <rom-file id="56112"><area-name id="247"/></rom-file>
-	  <rom-file id="55990"><area-name id="125"/></rom-file>
-	</category>
-	<category><name><region-name id="017"/></name>
-	  <rom-file id="55978"><area-name id="113"/></rom-file>
-	  <rom-file id="56066"><area-name id="201"/></rom-file>
-	  <rom-file id="56077"><area-name id="212"/></rom-file>
-	  <rom-file id="56039"><area-name id="174"/></rom-file>
-	  <rom-file id="55993"><area-name id="128"/></rom-file>
-	</category>
-	<category><name><region-name id="018"/></name>
-	  <rom-file id="56115"><area-name id="250"/></rom-file>
-	  <rom-file id="56117"><area-name id="252"/></rom-file>
-	  <rom-file id="56041"><area-name id="176"/></rom-file>
-	  <rom-file id="55988"><area-name id="123"/></rom-file>
-	</category>
-	<category><name><region-name id="019"/></name>
-	  <rom-file id="56072"><area-name id="207"/></rom-file>
-	  <rom-file id="56076"><area-name id="211"/></rom-file>
-	  <rom-file id="56025"><area-name id="160"/></rom-file>
-	  <rom-file id="56070"><area-name id="205"/></rom-file>
-	  <rom-file id="56028"><area-name id="163"/></rom-file>
-	  <rom-file id="56024"><area-name id="159"/></rom-file>
-	  <rom-file id="55989"><area-name id="124"/></rom-file>
-	</category>
-	<category><name><region-name id="020"/></name>
-	  <rom-file id="56045"><area-name id="180"/></rom-file>
-	  <rom-file id="55995"><area-name id="130"/></rom-file>
-	  <rom-file id="56046"><area-name id="181"/></rom-file>
-	  <rom-file id="56043"><area-name id="178"/></rom-file>
-	  <rom-file id="56042"><area-name id="177"/></rom-file>
-	</category>
-	<category><name><region-name id="021"/></name>
-	  <rom-file id="55999"><area-name id="134"/></rom-file>
-	  <rom-file id="56000"><area-name id="135"/></rom-file>
-	  <rom-file id="55905"><area-name id="040"/></rom-file>
-	  <rom-file id="56050"><area-name id="185"/></rom-file>
-	  <rom-file id="55906"><area-name id="041"/></rom-file>
-	  <rom-file id="56051"><area-name id="186"/></rom-file>
-	  <rom-file id="55907"><area-name id="042"/></rom-file>
-	  <rom-file id="55904"><area-name id="039"/></rom-file>
-	  <rom-file id="56052"><area-name id="187"/></rom-file>
-	  <rom-file id="56053"><area-name id="188"/></rom-file>
-	</category>
-      </category>
-      <category><name>&amp;<i18n-string id="FFXI3"/></name>
-	<category><name><region-name id="022"/></name>
-	  <rom-file id="55877"><area-name id="012"/></rom-file>
-	  <rom-file id="55878"><area-name id="013"/></rom-file>
-	  <rom-file id="55876"><area-name id="011"/></rom-file>
-	</category>
-	<category><name><region-name id="023"/></name>
-	  <rom-file id="55891"><area-name id="026"/></rom-file>
-	</category>
-	<category><name><region-name id="024"/></name>
-	  <rom-file id="55889"><area-name id="024"/></rom-file>
-	  <rom-file id="55890"><area-name id="025"/></rom-file>
-	  <rom-file id="55892"><area-name id="027"/></rom-file>
-	  <rom-file id="55893"><area-name id="028"/></rom-file>
-	  <rom-file id="55894"><area-name id="029"/></rom-file>
-	  <rom-file id="55895"><area-name id="030"/></rom-file>
-	  <rom-file id="55896"><area-name id="031"/></rom-file>
-	  <rom-file id="55897"><area-name id="032"/></rom-file>
-	</category>
-	<category><name><region-name id="025"/></name>
-	  <rom-file id="55879"><area-name id="014"/></rom-file>
-	  <rom-file id="55883"><area-name id="018"/></rom-file>
-	  <rom-file id="55881"><area-name id="016"/></rom-file>
-	  <rom-file id="55885"><area-name id="020"/></rom-file>
-	  <rom-file id="55887"><area-name id="022"/></rom-file>
-	  <rom-file id="55884"><area-name id="019"/></rom-file>
-	  <rom-file id="55882"><area-name id="017"/></rom-file>
-	  <rom-file id="55886"><area-name id="021"/></rom-file>
-	  <rom-file id="55888"><area-name id="023"/></rom-file>
-	</category>
-	<category><name><region-name id="026"/></name>
-	  <rom-file id="55898"><area-name id="033"/></rom-file>
-	  <rom-file id="55901"><area-name id="036"/></rom-file>
-	  <rom-file id="55899"><area-name id="034"/></rom-file>
-	  <rom-file id="55900"><area-name id="035"/></rom-file>
-	</category>
-	<category><name><region-name id="027"/></name>
-	  <rom-file id="55903"><area-name id="038"/></rom-file>
-	  <rom-file id="55902"><area-name id="037"/></rom-file>
-	</category>
-      </category>
-      <category><name>&amp;<i18n-string id="FFXI4"/></name>
-	<category><name><region-name id="028"/></name></category>
-	<category><name><region-name id="029"/></name>
-	  <rom-file id="55915"><area-name id="050"/></rom-file>
-	  <rom-file id="55977"><area-name id="050"/>-2</rom-file>
-	  <rom-file id="55913"><area-name id="048"/></rom-file>
-	  <rom-file id="55917"><area-name id="052"/></rom-file>
-	  <rom-file id="55935"><area-name id="070"/></rom-file>
-	  <rom-file id="55936"><area-name id="071"/></rom-file>
-	</category>
-	<category><name><region-name id="030"/></name>
-	  <rom-file id="55933"><area-name id="068"/></rom-file>
-	  <rom-file id="55932"><area-name id="067"/></rom-file>
-	  <rom-file id="55930"><area-name id="065"/></rom-file>
-	  <rom-file id="55931"><area-name id="066"/></rom-file>
-	  <rom-file id="55916"><area-name id="051"/></rom-file>
-	</category>
-	<category><name><region-name id="031"/></name>
-	  <rom-file id="55927"><area-name id="062"/></rom-file>
-	  <rom-file id="55928"><area-name id="063"/></rom-file>
-	  <rom-file id="55926"><area-name id="061"/></rom-file>
-	  <rom-file id="55929"><area-name id="064"/></rom-file>
-	</category>
-	<category><name><region-name id="032"/></name>
-	  <rom-file id="55919"><area-name id="054"/></rom-file>
-	  <rom-file id="55944"><area-name id="079"/></rom-file>
-	  <rom-file id="55943"><area-name id="078"/></rom-file>
-	  <rom-file id="55920"><area-name id="055"/></rom-file>
-	  <rom-file id="55934"><area-name id="069"/></rom-file>
-	  <rom-file id="55918"><area-name id="053"/></rom-file>
-	  <rom-file id="55921"><area-name id="056"/></rom-file>
-	  <rom-file id="55922"><area-name id="057"/></rom-file>
-	  <rom-file id="55925"><area-name id="060"/></rom-file>
-	</category>
-	<category><name><region-name id="033"/></name>
-	  <rom-file id="55937"><area-name id="072"/></rom-file>
-	  <rom-file id="55939"><area-name id="074"/></rom-file>
-	  <rom-file id="55940"><area-name id="075"/></rom-file>
-	  <rom-file id="55942"><area-name id="077"/></rom-file>
-	  <rom-file id="55941"><area-name id="076"/></rom-file>
-	  <rom-file id="55938"><area-name id="073"/></rom-file>
-	</category>
-      </category>
-      <category><name>&amp;<i18n-string id="FFXI5"/></name>
-	<category><name><region-name id="034"/></name>
-	  <rom-file id="55946"><area-name id="081"/></rom-file>
-	  <rom-file id="55951"><area-name id="086"/></rom-file>
-	  <rom-file id="55945"><area-name id="080"/></rom-file>
-	</category>
-	<category><name><region-name id="035"/></name>
-	  <rom-file id="55949"><area-name id="084"/></rom-file>
-	  <rom-file id="55947"><area-name id="082"/></rom-file>
-	  <rom-file id="55950"><area-name id="085"/></rom-file>
-	  <rom-file id="56040"><area-name id="175"/></rom-file>
-	</category>
-	<category><name><region-name id="036"/></name>
-	  <rom-file id="55952"><area-name id="087"/></rom-file>
-	  <rom-file id="55954"><area-name id="089"/></rom-file>
-	  <rom-file id="55953"><area-name id="088"/></rom-file>
-	  <rom-file id="55958"><area-name id="093"/></rom-file>
-	</category>
-	<category><name><region-name id="037"/></name>
-	  <rom-file id="55957"><area-name id="092"/></rom-file>
-	  <rom-file id="56036"><area-name id="171"/></rom-file>
-	  <rom-file id="55955"><area-name id="090"/></rom-file>
-	  <rom-file id="55956"><area-name id="091"/></rom-file>
-	  <rom-file id="55948"><area-name id="083"/></rom-file>
-	</category>
-	<category><name><region-name id="038"/></name>
-	  <rom-file id="55961"><area-name id="096"/></rom-file>
-	  <rom-file id="55994"><area-name id="129"/></rom-file>
-	  <rom-file id="55960"><area-name id="095"/></rom-file>
-	  <rom-file id="55959"><area-name id="094"/></rom-file>
-	</category>
-	<category><name><region-name id="039"/></name>
-	  <rom-file id="55964"><area-name id="099"/></rom-file>
-	  <rom-file id="56029"><area-name id="164"/></rom-file>
-	  <rom-file id="55962"><area-name id="097"/></rom-file>
-	  <rom-file id="55963"><area-name id="098"/></rom-file>
-	</category>
-	<category><name><region-name id="040"/></name>
-	  <rom-file id="56001"><area-name id="136"/></rom-file>
-	</category>
-	<category><name><region-name id="041"/></name>
-	  <rom-file id="56003"><area-name id="138"/></rom-file>
-	  <rom-file id="56020"><area-name id="155"/></rom-file>
-	  <rom-file id="56021"><area-name id="156"/></rom-file>
-	  <rom-file id="56002"><area-name id="137"/></rom-file>
-	</category>
-	<category><name><region-name id="042"/></name>
-	</category>
-	<category><name><region-name id="043"/></name>
-	</category>
-	<category><name><region-name id="044"/></name>
-	</category>
-	<category><name><region-name id="045"/></name>
-	</category>
-	<category><name><region-name id="047"/></name>
-		<rom-file id="56047"><area-name id="182"/></rom-file>
-		<rom-file id="56087"><area-name id="222"/></rom-file>
-	</category>
-      </category>
-      <category><name><i18n-string id="Menu:Abyssea"/></name>
-	<rom-file id="56080"><area-name id="215"/></rom-file>
-	<rom-file id="55880"><area-name id="015"/></rom-file>
-	<rom-file id="55997"><area-name id="132"/></rom-file>
-	<rom-file id="56081"><area-name id="216"/></rom-file>
-	<rom-file id="55910"><area-name id="045"/></rom-file>
-	<rom-file id="56082"><area-name id="217"/></rom-file>
-	<rom-file id="56083"><area-name id="218"/></rom-file>
-	<rom-file id="56118"><area-name id="253"/></rom-file>
-	<rom-file id="56119"><area-name id="254"/></rom-file>
-	<rom-file id="56120"><area-name id="255"/></rom-file>
-      </category>
-      <category><name><i18n-string id="Menu:Other"/></name>
-	<rom-file id="56089"><area-name id="224"/></rom-file>
-	<rom-file id="56091"><area-name id="226"/></rom-file>
-	<rom-file id="56088"><area-name id="223"/></rom-file>
-	<rom-file id="56090"><area-name id="225"/></rom-file>
-	<separator/>
-	<rom-file id="56086"><area-name id="221"/></rom-file>
-	<rom-file id="56093"><area-name id="228"/> <i18n-string id="Menu:WithPirates"/></rom-file>
-	<rom-file id="56085"><area-name id="220"/></rom-file>
-	<rom-file id="56092"><area-name id="227"/> <i18n-string id="Menu:WithPirates"/></rom-file>
-	<separator/>
-	<rom-file id="55911"><area-name id="046"/></rom-file>
-	<rom-file id="55912"><area-name id="047"/></rom-file>
-	<rom-file id="55923"><area-name id="058"/></rom-file>
-	<rom-file id="55924"><area-name id="059"/></rom-file>
-	<separator/>
-	<rom-file id="55908"><area-name id="043"/></rom-file>
-	<rom-file id="55909"><area-name id="044"/></rom-file>
-	<rom-file id="56048"><area-name id="183"/></rom-file>
-	<separator/>
-	<rom-file id="55851"><i18n-string id="Menu:MonsterSkillNames"/></rom-file>
-      </category>
+    <category><name><i18n-string id="Menu:ItemData"/></name>
+        <category><name><i18n-string id="Menu:English"/></name>
+            <rom-file id="00076"><i18n-string id="Menu:Armor"/></rom-file>
+            <rom-file id="55668"><i18n-string id="Menu:Armor"/> 2</rom-file>
+            <rom-file id="00091"><i18n-string id="Menu:Currency"/></rom-file>
+            <rom-file id="00073"><i18n-string id="Menu:GeneralItems"/></rom-file>
+            <rom-file id="55671"><i18n-string id="Menu:GeneralItems"/> 2</rom-file>
+            <rom-file id="00077"><i18n-string id="Menu:PuppetItems"/></rom-file>
+            <rom-file id="00074"><i18n-string id="Menu:UsableItems"/></rom-file>
+            <rom-file id="00075"><i18n-string id="Menu:Weapons"/></rom-file>
+            <rom-file id="55667"><i18n-string id="Menu:VouchersAndSlips"/></rom-file>
+            <rom-file id="55669"><i18n-string id="Menu:Monipulator"/></rom-file>
+            <rom-file id="55670"><i18n-string id="Menu:Instincts"/></rom-file>
+        </category>
+        <category><name><i18n-string id="Menu:French"/></name>
+            <rom-file id="56238"><i18n-string id="Menu:Armor"/></rom-file>
+            <rom-file id="56208"><i18n-string id="Menu:Armor"/> 2</rom-file>
+            <rom-file id="56240"><i18n-string id="Menu:Currency"/></rom-file>
+            <rom-file id="56235"><i18n-string id="Menu:GeneralItems"/></rom-file>
+            <rom-file id="56211"><i18n-string id="Menu:GeneralItems"/> 2</rom-file>
+            <rom-file id="56239"><i18n-string id="Menu:PuppetItems"/></rom-file>
+            <rom-file id="56236"><i18n-string id="Menu:UsableItems"/></rom-file>
+            <rom-file id="56237"><i18n-string id="Menu:Weapons"/></rom-file>
+            <rom-file id="56207"><i18n-string id="Menu:VouchersAndSlips"/></rom-file>
+        </category>
+        <category><name><i18n-string id="Menu:German"/></name>
+            <rom-file id="55818"><i18n-string id="Menu:Armor"/></rom-file>
+            <rom-file id="55788"><i18n-string id="Menu:Armor"/> 2</rom-file>
+            <rom-file id="55820"><i18n-string id="Menu:Currency"/></rom-file>
+            <rom-file id="55815"><i18n-string id="Menu:GeneralItems"/></rom-file>
+            <rom-file id="55791"><i18n-string id="Menu:GeneralItems"/> 2</rom-file>
+            <rom-file id="55819"><i18n-string id="Menu:PuppetItems"/></rom-file>
+            <rom-file id="55816"><i18n-string id="Menu:UsableItems"/></rom-file>
+            <rom-file id="55817"><i18n-string id="Menu:Weapons"/></rom-file>
+            <rom-file id="56787"><i18n-string id="Menu:VouchersAndSlips"/></rom-file>
+        </category>
+        <category><name><i18n-string id="Menu:Japanese"/></name>
+            <rom-file id="00007"><i18n-string id="Menu:Armor"/></rom-file>
+            <rom-file id="55548"><i18n-string id="Menu:Armor"/> 2</rom-file>
+            <rom-file id="00009"><i18n-string id="Menu:Currency"/></rom-file>
+            <rom-file id="00004"><i18n-string id="Menu:GeneralItems"/></rom-file>
+            <rom-file id="55551"><i18n-string id="Menu:GeneralItems"/> 2</rom-file>
+            <rom-file id="00008"><i18n-string id="Menu:PuppetItems"/></rom-file>
+            <rom-file id="00005"><i18n-string id="Menu:UsableItems"/></rom-file>
+            <rom-file id="00006"><i18n-string id="Menu:Weapons"/></rom-file>
+            <rom-file id="55547"><i18n-string id="Menu:VouchersAndSlips"/></rom-file>
+        </category>
     </category>
-    <!-- Japanese: 06120-06375 -->
-    <category><name><i18n-string id="Menu:Japanese"/></name>
-      <category><name>&amp;<i18n-string id="FFXI1"/></name>
-	<category><name><region-name id="000"/></name>
-	  <rom-file id="06353"><area-name id="233"/></rom-file>
-	  <rom-file id="06351"><area-name id="231"/></rom-file>
-	  <rom-file id="06352"><area-name id="232"/></rom-file>
-	  <rom-file id="06350"><area-name id="230"/></rom-file>
-	</category>
-	<category><name><region-name id="001"/></name>
-	  <rom-file id="06355"><area-name id="235"/></rom-file>
-	  <rom-file id="06354"><area-name id="234"/></rom-file>
-	  <rom-file id="06357"><area-name id="237"/></rom-file>
-	  <rom-file id="06356"><area-name id="236"/></rom-file>
-	</category>
-	<category><name><region-name id="002"/></name>
-	  <rom-file id="06362"><area-name id="242"/></rom-file>
-	  <rom-file id="06360"><area-name id="240"/></rom-file>
-	  <rom-file id="06359"><area-name id="239"/></rom-file>
-	  <rom-file id="06358"><area-name id="238"/></rom-file>
-	  <rom-file id="06361"><area-name id="241"/></rom-file>
-	</category>
-	<category><name><region-name id="003"/></name>
-	  <rom-file id="06365"><area-name id="245"/></rom-file>
-	  <rom-file id="06366"><area-name id="246"/></rom-file>
-	  <rom-file id="06363"><area-name id="243"/></rom-file>
-	  <rom-file id="06364"><area-name id="244"/></rom-file>
-	</category>
-	<category><name><region-name id="004"/></name>
-	  <rom-file id="06287"><area-name id="167"/></rom-file>
-	  <rom-file id="06221"><area-name id="101"/></rom-file>
-	  <rom-file id="06261"><area-name id="141"/></rom-file>
-	  <rom-file id="06260"><area-name id="140"/></rom-file>
-	  <rom-file id="06259"><area-name id="139"/></rom-file>
-	  <rom-file id="06310"><area-name id="190"/></rom-file>
-	  <rom-file id="06220"><area-name id="100"/></rom-file>
-	  <rom-file id="06262"><area-name id="142"/></rom-file>
-	</category>
-	<category><name><region-name id="005"/></name>
-	  <rom-file id="06316"><area-name id="196"/></rom-file>
-	  <rom-file id="06228"><area-name id="108"/></rom-file>
-	  <rom-file id="06222"><area-name id="102"/></rom-file>
-	  <rom-file id="06313"><area-name id="193"/></rom-file>
-	  <rom-file id="06368"><area-name id="248"/></rom-file>
-	  <rom-file id="06223"><area-name id="103"/></rom-file>
-	</category>
-	<category><name><region-name id="006"/></name>
-	  <rom-file id="06225"><area-name id="105"/></rom-file>
-	  <rom-file id="06122"><area-name id="002"/></rom-file>
-	  <rom-file id="06269"><area-name id="149"/></rom-file>
-	  <rom-file id="06224"><area-name id="104"/></rom-file>
-	  <rom-file id="06270"><area-name id="150"/></rom-file>
-	  <rom-file id="06121"><area-name id="001"/></rom-file>
-	  <rom-file id="06315"><area-name id="195"/></rom-file>
-	</category>
-	<category><name><region-name id="007"/></name>
-	  <rom-file id="06311"><area-name id="191"/></rom-file>
-	  <rom-file id="06293"><area-name id="173"/></rom-file>
-	  <rom-file id="06226"><area-name id="106"/></rom-file>
-	  <rom-file id="06263"><area-name id="143"/></rom-file>
-	  <rom-file id="06227"><area-name id="107"/></rom-file>
-	  <rom-file id="06264"><area-name id="144"/></rom-file>
-	  <rom-file id="06292"><area-name id="172"/></rom-file>
-	</category>
-	<category><name><region-name id="008"/></name>
-	  <rom-file id="06267"><area-name id="147"/></rom-file>
-	  <rom-file id="06317"><area-name id="197"/></rom-file>
-	  <rom-file id="06229"><area-name id="109"/></rom-file>
-	  <rom-file id="06268"><area-name id="148"/></rom-file>
-	  <rom-file id="06230"><area-name id="110"/></rom-file>
-	</category>
-	<category><name><region-name id="009"/></name>
-	  <rom-file id="06266"><area-name id="146"/></rom-file>
-	  <rom-file id="06236"><area-name id="116"/></rom-file>
-	  <rom-file id="06290"><area-name id="170"/></rom-file>
-	  <rom-file id="06265"><area-name id="145"/></rom-file>
-	  <rom-file id="06312"><area-name id="192"/></rom-file>
-	  <rom-file id="06314"><area-name id="194"/></rom-file>
-	  <rom-file id="06289"><area-name id="169"/></rom-file>
-	  <rom-file id="06235"><area-name id="115"/></rom-file>
-	</category>
-	<category><name><region-name id="010"/></name>
-	  <rom-file id="06124"><area-name id="004"/></rom-file>
-	  <rom-file id="06238"><area-name id="118"/></rom-file>
-	  <rom-file id="06333"><area-name id="213"/></rom-file>
-	  <rom-file id="06123"><area-name id="003"/></rom-file>
-	  <rom-file id="06318"><area-name id="198"/></rom-file>
-	  <rom-file id="06369"><area-name id="249"/></rom-file>
-	  <rom-file id="06237"><area-name id="117"/></rom-file>
-	</category>
-	<category><name><region-name id="011"/></name>
-	  <rom-file id="06272"><area-name id="152"/></rom-file>
-	  <rom-file id="06127"><area-name id="007"/></rom-file>
-	  <rom-file id="06128"><area-name id="008"/></rom-file>
-	  <rom-file id="06271"><area-name id="151"/></rom-file>
-	  <rom-file id="06320"><area-name id="200"/></rom-file>
-	  <rom-file id="06239"><area-name id="119"/></rom-file>
-	  <rom-file id="06240"><area-name id="120"/></rom-file>
-	</category>
-	<category><name><region-name id="012"/></name>
-	  <rom-file id="06231"><area-name id="111"/></rom-file>
-	  <rom-file id="06323"><area-name id="203"/></rom-file>
-	  <rom-file id="06324"><area-name id="204"/></rom-file>
-	  <rom-file id="06129"><area-name id="009"/></rom-file>
-	  <rom-file id="06326"><area-name id="206"/></rom-file>
-	  <rom-file id="06286"><area-name id="166"/></rom-file>
-	  <rom-file id="06130"><area-name id="010"/></rom-file>
-	</category>
-	<category><name><region-name id="013"/></name>
-	  <rom-file id="06126"><area-name id="006"/></rom-file>
-	  <rom-file id="06281"><area-name id="161"/></rom-file>
-	  <rom-file id="06282"><area-name id="162"/></rom-file>
-	  <rom-file id="06285"><area-name id="165"/></rom-file>
-	  <rom-file id="06125"><area-name id="005"/></rom-file>
-	  <rom-file id="06232"><area-name id="112"/></rom-file>
-	</category>
-	<category><name><region-name id="014"/></name>
-	  <rom-file id="06247"><area-name id="127"/></rom-file>
-	  <rom-file id="06304"><area-name id="184"/></rom-file>
-	  <rom-file id="06277"><area-name id="157"/></rom-file>
-	  <rom-file id="06251"><area-name id="131"/></rom-file>
-	  <rom-file id="06246"><area-name id="126"/></rom-file>
-	  <rom-file id="06299"><area-name id="179"/></rom-file>
-	  <rom-file id="06278"><area-name id="158"/></rom-file>
-	</category>
-      </category>
-      <category><name>&amp;<i18n-string id="FFXI2"/></name>
-	<category><name><region-name id="015"/></name>
-	  <rom-file id="06322"><area-name id="202"/></rom-file>
-	  <rom-file id="06274"><area-name id="154"/></rom-file>
-	  <rom-file id="06371"><area-name id="251"/></rom-file>
-	  <rom-file id="06242"><area-name id="122"/></rom-file>
-	  <rom-file id="06273"><area-name id="153"/></rom-file>
-	  <rom-file id="06241"><area-name id="121"/></rom-file>
-	</category>
-	<category><name><region-name id="016"/></name>
-	  <rom-file id="06288"><area-name id="168"/></rom-file>
-	  <rom-file id="06329"><area-name id="209"/></rom-file>
-	  <rom-file id="06234"><area-name id="114"/></rom-file>
-	  <rom-file id="06328"><area-name id="208"/></rom-file>
-	  <rom-file id="06367"><area-name id="247"/></rom-file>
-	  <rom-file id="06245"><area-name id="125"/></rom-file>
-	</category>
-	<category><name><region-name id="017"/></name>
-	  <rom-file id="06233"><area-name id="113"/></rom-file>
-	  <rom-file id="06321"><area-name id="201"/></rom-file>
-	  <rom-file id="06332"><area-name id="212"/></rom-file>
-	  <rom-file id="06294"><area-name id="174"/></rom-file>
-	  <rom-file id="06248"><area-name id="128"/></rom-file>
-	</category>
-	<category><name><region-name id="018"/></name>
-	  <rom-file id="06370"><area-name id="250"/></rom-file>
-	  <rom-file id="06372"><area-name id="252"/></rom-file>
-	  <rom-file id="06296"><area-name id="176"/></rom-file>
-	  <rom-file id="06243"><area-name id="123"/></rom-file>
-	</category>
-	<category><name><region-name id="019"/></name>
-	  <rom-file id="06327"><area-name id="207"/></rom-file>
-	  <rom-file id="06331"><area-name id="211"/></rom-file>
-	  <rom-file id="06280"><area-name id="160"/></rom-file>
-	  <rom-file id="06325"><area-name id="205"/></rom-file>
-	  <rom-file id="06283"><area-name id="163"/></rom-file>
-	  <rom-file id="06279"><area-name id="159"/></rom-file>
-	  <rom-file id="06244"><area-name id="124"/></rom-file>
-	</category>
-	<category><name><region-name id="020"/></name>
-	  <rom-file id="06300"><area-name id="180"/></rom-file>
-	  <rom-file id="06250"><area-name id="130"/></rom-file>
-	  <rom-file id="06301"><area-name id="181"/></rom-file>
-	  <rom-file id="06298"><area-name id="178"/></rom-file>
-	  <rom-file id="06297"><area-name id="177"/></rom-file>
-	</category>
-	<category><name><region-name id="021"/></name>
-	  <rom-file id="06254"><area-name id="134"/></rom-file>
-	  <rom-file id="06255"><area-name id="135"/></rom-file>
-	  <rom-file id="06160"><area-name id="040"/></rom-file>
-	  <rom-file id="06305"><area-name id="185"/></rom-file>
-	  <rom-file id="06161"><area-name id="041"/></rom-file>
-	  <rom-file id="06306"><area-name id="186"/></rom-file>
-	  <rom-file id="06162"><area-name id="042"/></rom-file>
-	  <rom-file id="06159"><area-name id="039"/></rom-file>
-	  <rom-file id="06307"><area-name id="187"/></rom-file>
-	  <rom-file id="06308"><area-name id="188"/></rom-file>
-	</category>
-      </category>
-      <category><name>&amp;<i18n-string id="FFXI3"/></name>
-	<category><name><region-name id="022"/></name>
-	  <rom-file id="06132"><area-name id="012"/></rom-file>
-	  <rom-file id="06133"><area-name id="013"/></rom-file>
-	  <rom-file id="06131"><area-name id="011"/></rom-file>
-	</category>
-	<category><name><region-name id="023"/></name>
-	  <rom-file id="06146"><area-name id="026"/></rom-file>
-	</category>
-	<category><name><region-name id="024"/></name>
-	  <rom-file id="06144"><area-name id="024"/></rom-file>
-	  <rom-file id="06145"><area-name id="025"/></rom-file>
-	  <rom-file id="06147"><area-name id="027"/></rom-file>
-	  <rom-file id="06148"><area-name id="028"/></rom-file>
-	  <rom-file id="06149"><area-name id="029"/></rom-file>
-	  <rom-file id="06150"><area-name id="030"/></rom-file>
-	  <rom-file id="06151"><area-name id="031"/></rom-file>
-	  <rom-file id="06152"><area-name id="032"/></rom-file>
-	</category>
-	<category><name><region-name id="025"/></name>
-	  <rom-file id="06134"><area-name id="014"/></rom-file>
-	  <rom-file id="06138"><area-name id="018"/></rom-file>
-	  <rom-file id="06136"><area-name id="016"/></rom-file>
-	  <rom-file id="06140"><area-name id="020"/></rom-file>
-	  <rom-file id="06142"><area-name id="022"/></rom-file>
-	  <rom-file id="06139"><area-name id="019"/></rom-file>
-	  <rom-file id="06137"><area-name id="017"/></rom-file>
-	  <rom-file id="06141"><area-name id="021"/></rom-file>
-	  <rom-file id="06143"><area-name id="023"/></rom-file>
-	</category>
-	<category><name><region-name id="026"/></name>
-	  <rom-file id="06153"><area-name id="033"/></rom-file>
-	  <rom-file id="06156"><area-name id="036"/></rom-file>
-	  <rom-file id="06154"><area-name id="034"/></rom-file>
-	  <rom-file id="06155"><area-name id="035"/></rom-file>
-	</category>
-	<category><name><region-name id="027"/></name>
-	  <rom-file id="06158"><area-name id="038"/></rom-file>
-	  <rom-file id="06157"><area-name id="037"/></rom-file>
-	</category>
-      </category>
-      <category><name>&amp;<i18n-string id="FFXI4"/></name>
-	<category><name><region-name id="028"/></name></category>
-	<category><name><region-name id="029"/></name>
-	  <rom-file id="06170"><area-name id="050"/></rom-file>
-	  <rom-file id="57913"><area-name id="050"/>-2</rom-file>
-	  <rom-file id="06168"><area-name id="048"/></rom-file>
-	  <rom-file id="06172"><area-name id="052"/></rom-file>
-	  <rom-file id="06190"><area-name id="070"/></rom-file>
-	  <rom-file id="06191"><area-name id="071"/></rom-file>
-	</category>
-	<category><name><region-name id="030"/></name>
-	  <rom-file id="06188"><area-name id="068"/></rom-file>
-	  <rom-file id="06187"><area-name id="067"/></rom-file>
-	  <rom-file id="06185"><area-name id="065"/></rom-file>
-	  <rom-file id="06186"><area-name id="066"/></rom-file>
-	  <rom-file id="06171"><area-name id="051"/></rom-file>
-	</category>
-	<category><name><region-name id="031"/></name>
-	  <rom-file id="06182"><area-name id="062"/></rom-file>
-	  <rom-file id="06183"><area-name id="063"/></rom-file>
-	  <rom-file id="06181"><area-name id="061"/></rom-file>
-	  <rom-file id="06184"><area-name id="064"/></rom-file>
-	</category>
-	<category><name><region-name id="032"/></name>
-	  <rom-file id="06174"><area-name id="054"/></rom-file>
-	  <rom-file id="06199"><area-name id="079"/></rom-file>
-	  <rom-file id="06198"><area-name id="078"/></rom-file>
-	  <rom-file id="06175"><area-name id="055"/></rom-file>
-	  <rom-file id="06189"><area-name id="069"/></rom-file>
-	  <rom-file id="06173"><area-name id="053"/></rom-file>
-	  <rom-file id="06176"><area-name id="056"/></rom-file>
-	  <rom-file id="06177"><area-name id="057"/></rom-file>
-	  <rom-file id="06180"><area-name id="060"/></rom-file>
-	</category>
-	<category><name><region-name id="033"/></name>
-	  <rom-file id="06192"><area-name id="072"/></rom-file>
-	  <rom-file id="06194"><area-name id="074"/></rom-file>
-	  <rom-file id="06195"><area-name id="075"/></rom-file>
-	  <rom-file id="06197"><area-name id="077"/></rom-file>
-	  <rom-file id="06196"><area-name id="076"/></rom-file>
-	  <rom-file id="06193"><area-name id="073"/></rom-file>
-	</category>
-      </category>
-      <category><name>&amp;<i18n-string id="FFXI5"/></name>
-	<category><name><region-name id="034"/></name>
-	  <rom-file id="06201"><area-name id="081"/></rom-file>
-	  <rom-file id="06206"><area-name id="086"/></rom-file>
-	  <rom-file id="06200"><area-name id="080"/></rom-file>
-	</category>
-	<category><name><region-name id="035"/></name>
-	  <rom-file id="06204"><area-name id="084"/></rom-file>
-	  <rom-file id="06202"><area-name id="082"/></rom-file>
-	  <rom-file id="06205"><area-name id="085"/></rom-file>
-	  <rom-file id="06295"><area-name id="175"/></rom-file>
-	</category>
-	<category><name><region-name id="036"/></name>
-	  <rom-file id="06207"><area-name id="087"/></rom-file>
-	  <rom-file id="06209"><area-name id="089"/></rom-file>
-	  <rom-file id="06208"><area-name id="088"/></rom-file>
-	  <rom-file id="06213"><area-name id="093"/></rom-file>
-	</category>
-	<category><name><region-name id="037"/></name>
-	  <rom-file id="06212"><area-name id="092"/></rom-file>
-	  <rom-file id="06291"><area-name id="171"/></rom-file>
-	  <rom-file id="06210"><area-name id="090"/></rom-file>
-	  <rom-file id="06211"><area-name id="091"/></rom-file>
-	  <rom-file id="06203"><area-name id="083"/></rom-file>
-	</category>
-	<category><name><region-name id="038"/></name>
-	  <rom-file id="06216"><area-name id="096"/></rom-file>
-	  <rom-file id="06249"><area-name id="129"/></rom-file>
-	  <rom-file id="06215"><area-name id="095"/></rom-file>
-	  <rom-file id="06214"><area-name id="094"/></rom-file>
-	</category>
-	<category><name><region-name id="039"/></name>
-	  <rom-file id="06219"><area-name id="099"/></rom-file>
-	  <rom-file id="06284"><area-name id="164"/></rom-file>
-	  <rom-file id="06217"><area-name id="097"/></rom-file>
-	  <rom-file id="06218"><area-name id="098"/></rom-file>
-	</category>
-	<category><name><region-name id="040"/></name>
-	  <rom-file id="06256"><area-name id="136"/></rom-file>
-	</category>
-	<category><name><region-name id="041"/></name>
-	  <rom-file id="06258"><area-name id="138"/></rom-file>
-	  <rom-file id="06275"><area-name id="155"/></rom-file>
-	  <rom-file id="06276"><area-name id="156"/></rom-file>
-	  <rom-file id="06257"><area-name id="137"/></rom-file>
-	</category>
-	<category><name><region-name id="042"/></name>
-	</category>
-	<category><name><region-name id="043"/></name>
-	</category>
-	<category><name><region-name id="044"/></name>
-	</category>
-	<category><name><region-name id="045"/></name>
-	</category>
-	<category><name><region-name id="047"/></name>
-		<rom-file id="06302"><area-name id="182"/></rom-file>
-		<rom-file id="06342"><area-name id="222"/></rom-file>
-	</category>
-      </category>
-      <category><name><i18n-string id="Menu:Abyssea"/></name>
-	<rom-file id="06335"><area-name id="215"/></rom-file>
-	<rom-file id="06135"><area-name id="015"/></rom-file>
-	<rom-file id="06252"><area-name id="132"/></rom-file>
-	<rom-file id="06336"><area-name id="216"/></rom-file>
-	<rom-file id="06165"><area-name id="045"/></rom-file>
-	<rom-file id="06337"><area-name id="217"/></rom-file>
-	<rom-file id="06338"><area-name id="218"/></rom-file>
-	<rom-file id="06373"><area-name id="253"/></rom-file>
-	<rom-file id="06174"><area-name id="254"/></rom-file>
-	<rom-file id="06375"><area-name id="255"/></rom-file>
-      </category>
-      <category><name><i18n-string id="Menu:Other"/></name>
-	<rom-file id="06344"><area-name id="224"/></rom-file>
-	<rom-file id="06346"><area-name id="226"/></rom-file>
-	<rom-file id="06343"><area-name id="223"/></rom-file>
-	<rom-file id="06345"><area-name id="225"/></rom-file>
-	<separator/>
-	<rom-file id="06341"><area-name id="221"/></rom-file>
-	<rom-file id="06348"><area-name id="228"/> <i18n-string id="Menu:WithPirates"/></rom-file>
-	<rom-file id="06340"><area-name id="220"/></rom-file>
-	<rom-file id="06347"><area-name id="227"/> <i18n-string id="Menu:WithPirates"/></rom-file>
-	<separator/>
-	<rom-file id="06166"><area-name id="046"/></rom-file>
-	<rom-file id="06167"><area-name id="047"/></rom-file>
-	<rom-file id="06178"><area-name id="058"/></rom-file>
-	<rom-file id="06179"><area-name id="059"/></rom-file>
-	<separator/>
-	<rom-file id="06163"><area-name id="043"/></rom-file>
-	<rom-file id="06164"><area-name id="044"/></rom-file>
-	<rom-file id="06303"><area-name id="183"/></rom-file>
-	<separator/>
-	<rom-file id="07034"><i18n-string id="Menu:MonsterSkillNames"/></rom-file>
-      </category>
+    <category><name><i18n-string id="Menu:MobLists"/></name>
+        <!-- Language Independent: 06720-06975 -->
+        <category><name>&amp;<i18n-string id="FFXI1"/></name>
+            <category><name><region-name id="000"/></name>
+                <rom-file id="06953"><area-name id="233"/></rom-file>
+                <rom-file id="06951"><area-name id="231"/></rom-file>
+                <rom-file id="06952"><area-name id="232"/></rom-file>
+                <rom-file id="06950"><area-name id="230"/></rom-file>
+            </category>
+            <category><name><region-name id="001"/></name>
+                <rom-file id="06955"><area-name id="235"/></rom-file>
+                <rom-file id="06954"><area-name id="234"/></rom-file>
+                <rom-file id="06957"><area-name id="237"/></rom-file>
+                <rom-file id="06956"><area-name id="236"/></rom-file>
+            </category>
+            <category><name><region-name id="002"/></name>
+                <rom-file id="06962"><area-name id="242"/></rom-file>
+                <rom-file id="06960"><area-name id="240"/></rom-file>
+                <rom-file id="06959"><area-name id="239"/></rom-file>
+                <rom-file id="06958"><area-name id="238"/></rom-file>
+                <rom-file id="06961"><area-name id="241"/></rom-file>
+            </category>
+            <category><name><region-name id="003"/></name>
+                <rom-file id="06965"><area-name id="245"/></rom-file>
+                <rom-file id="06966"><area-name id="246"/></rom-file>
+                <rom-file id="06963"><area-name id="243"/></rom-file>
+                <rom-file id="06964"><area-name id="244"/></rom-file>
+            </category>
+            <category><name><region-name id="004"/></name>
+                <rom-file id="06887"><area-name id="167"/></rom-file>
+                <rom-file id="06821"><area-name id="101"/></rom-file>
+                <rom-file id="06861"><area-name id="141"/></rom-file>
+                <rom-file id="06860"><area-name id="140"/></rom-file>
+                <rom-file id="06859"><area-name id="139"/></rom-file>
+                <rom-file id="06910"><area-name id="190"/></rom-file>
+                <rom-file id="06820"><area-name id="100"/></rom-file>
+                <rom-file id="06862"><area-name id="142"/></rom-file>
+            </category>
+            <category><name><region-name id="005"/></name>
+                <rom-file id="06916"><area-name id="196"/></rom-file>
+                <rom-file id="06828"><area-name id="108"/></rom-file>
+                <rom-file id="06822"><area-name id="102"/></rom-file>
+                <rom-file id="06913"><area-name id="193"/></rom-file>
+                <rom-file id="06968"><area-name id="248"/></rom-file>
+                <rom-file id="06823"><area-name id="103"/></rom-file>
+            </category>
+            <category><name><region-name id="006"/></name>
+                <rom-file id="06825"><area-name id="105"/></rom-file>
+                <rom-file id="06722"><area-name id="002"/></rom-file>
+                <rom-file id="06869"><area-name id="149"/></rom-file>
+                <rom-file id="06824"><area-name id="104"/></rom-file>
+                <rom-file id="06870"><area-name id="150"/></rom-file>
+                <rom-file id="06721"><area-name id="001"/></rom-file>
+                <rom-file id="06915"><area-name id="195"/></rom-file>
+            </category>
+            <category><name><region-name id="007"/></name>
+                <rom-file id="06911"><area-name id="191"/></rom-file>
+                <rom-file id="06893"><area-name id="173"/></rom-file>
+                <rom-file id="06826"><area-name id="106"/></rom-file>
+                <rom-file id="06863"><area-name id="143"/></rom-file>
+                <rom-file id="06827"><area-name id="107"/></rom-file>
+                <rom-file id="06864"><area-name id="144"/></rom-file>
+                <rom-file id="06892"><area-name id="172"/></rom-file>
+            </category>
+            <category><name><region-name id="008"/></name>
+                <rom-file id="06867"><area-name id="147"/></rom-file>
+                <rom-file id="06917"><area-name id="197"/></rom-file>
+                <rom-file id="06829"><area-name id="109"/></rom-file>
+                <rom-file id="06868"><area-name id="148"/></rom-file>
+                <rom-file id="06830"><area-name id="110"/></rom-file>
+            </category>
+            <category><name><region-name id="009"/></name>
+                <rom-file id="06866"><area-name id="146"/></rom-file>
+                <rom-file id="06836"><area-name id="116"/></rom-file>
+                <rom-file id="06890"><area-name id="170"/></rom-file>
+                <rom-file id="06865"><area-name id="145"/></rom-file>
+                <rom-file id="06912"><area-name id="192"/></rom-file>
+                <rom-file id="06914"><area-name id="194"/></rom-file>
+                <rom-file id="06889"><area-name id="169"/></rom-file>
+                <rom-file id="06835"><area-name id="115"/></rom-file>
+            </category>
+            <category><name><region-name id="010"/></name>
+                <rom-file id="06724"><area-name id="004"/></rom-file>
+                <rom-file id="06838"><area-name id="118"/></rom-file>
+                <rom-file id="06933"><area-name id="213"/></rom-file>
+                <rom-file id="06723"><area-name id="003"/></rom-file>
+                <rom-file id="06918"><area-name id="198"/></rom-file>
+                <rom-file id="06969"><area-name id="249"/></rom-file>
+                <rom-file id="06837"><area-name id="117"/></rom-file>
+            </category>
+            <category><name><region-name id="011"/></name>
+                <rom-file id="06872"><area-name id="152"/></rom-file>
+                <rom-file id="06727"><area-name id="007"/></rom-file>
+                <rom-file id="06728"><area-name id="008"/></rom-file>
+                <rom-file id="06871"><area-name id="151"/></rom-file>
+                <rom-file id="06920"><area-name id="200"/></rom-file>
+                <rom-file id="06839"><area-name id="119"/></rom-file>
+                <rom-file id="06840"><area-name id="120"/></rom-file>
+            </category>
+            <category><name><region-name id="012"/></name>
+                <rom-file id="06831"><area-name id="111"/></rom-file>
+                <rom-file id="06923"><area-name id="203"/></rom-file>
+                <rom-file id="06924"><area-name id="204"/></rom-file>
+                <rom-file id="06729"><area-name id="009"/></rom-file>
+                <rom-file id="06886"><area-name id="166"/></rom-file>
+                <rom-file id="06926"><area-name id="206"/></rom-file>
+                <rom-file id="06730"><area-name id="010"/></rom-file>
+            </category>
+            <category><name><region-name id="013"/></name>
+                <rom-file id="06726"><area-name id="006"/></rom-file>
+                <rom-file id="06881"><area-name id="161"/></rom-file>
+                <rom-file id="06882"><area-name id="162"/></rom-file>
+                <rom-file id="06885"><area-name id="165"/></rom-file>
+                <rom-file id="06725"><area-name id="005"/></rom-file>
+                <rom-file id="06832"><area-name id="112"/></rom-file>
+            </category>
+            <category><name><region-name id="014"/></name>
+                <rom-file id="06847"><area-name id="127"/></rom-file>
+                <rom-file id="06904"><area-name id="184"/></rom-file>
+                <rom-file id="06877"><area-name id="157"/></rom-file>
+                <rom-file id="06851"><area-name id="131"/></rom-file>
+                <rom-file id="06846"><area-name id="126"/></rom-file>
+                <rom-file id="06899"><area-name id="179"/></rom-file>
+                <rom-file id="06878"><area-name id="158"/></rom-file>
+            </category>
+        </category>
+        <category><name>&amp;<i18n-string id="FFXI2"/></name>
+            <category><name><region-name id="015"/></name>
+                <rom-file id="06922"><area-name id="202"/></rom-file>
+                <rom-file id="06874"><area-name id="154"/></rom-file>
+                <rom-file id="06971"><area-name id="251"/></rom-file>
+                <rom-file id="06842"><area-name id="122"/></rom-file>
+                <rom-file id="06873"><area-name id="153"/></rom-file>
+                <rom-file id="06841"><area-name id="121"/></rom-file>
+            </category>
+            <category><name><region-name id="016"/></name>
+                <rom-file id="06888"><area-name id="168"/></rom-file>
+                <rom-file id="06929"><area-name id="209"/></rom-file>
+                <rom-file id="06834"><area-name id="114"/></rom-file>
+                <rom-file id="06928"><area-name id="208"/></rom-file>
+                <rom-file id="06967"><area-name id="247"/></rom-file>
+                <rom-file id="06845"><area-name id="125"/></rom-file>
+            </category>
+            <category><name><region-name id="017"/></name>
+                <rom-file id="06833"><area-name id="113"/></rom-file>
+                <rom-file id="06921"><area-name id="201"/></rom-file>
+                <rom-file id="06932"><area-name id="212"/></rom-file>
+                <rom-file id="06894"><area-name id="174"/></rom-file>
+                <rom-file id="06848"><area-name id="128"/></rom-file>
+            </category>
+            <category><name><region-name id="018"/></name>
+                <rom-file id="06970"><area-name id="250"/></rom-file>
+                <rom-file id="06972"><area-name id="252"/></rom-file>
+                <rom-file id="06896"><area-name id="176"/></rom-file>
+                <rom-file id="06843"><area-name id="123"/></rom-file>
+            </category>
+            <category><name><region-name id="019"/></name>
+                <rom-file id="06927"><area-name id="207"/></rom-file>
+                <rom-file id="06931"><area-name id="211"/></rom-file>
+                <rom-file id="06880"><area-name id="160"/></rom-file>
+                <rom-file id="06925"><area-name id="205"/></rom-file>
+                <rom-file id="06883"><area-name id="163"/></rom-file>
+                <rom-file id="06879"><area-name id="159"/></rom-file>
+                <rom-file id="06844"><area-name id="124"/></rom-file>
+            </category>
+            <category><name><region-name id="020"/></name>
+                <rom-file id="06900"><area-name id="180"/></rom-file>
+                <rom-file id="06850"><area-name id="130"/></rom-file>
+                <rom-file id="06901"><area-name id="181"/></rom-file>
+                <rom-file id="06898"><area-name id="178"/></rom-file>
+                <rom-file id="06897"><area-name id="177"/></rom-file>
+            </category>
+            <category><name><region-name id="021"/></name>
+                <rom-file id="06906"><area-name id="186"/></rom-file>
+                <rom-file id="06854"><area-name id="134"/></rom-file>
+                <rom-file id="06760"><area-name id="040"/></rom-file>
+                <rom-file id="06908"><area-name id="188"/></rom-file>
+                <rom-file id="06761"><area-name id="041"/></rom-file>
+                <rom-file id="06905"><area-name id="185"/></rom-file>
+                <rom-file id="06762"><area-name id="042"/></rom-file>
+                <rom-file id="06759"><area-name id="039"/></rom-file>
+                <rom-file id="06907"><area-name id="187"/></rom-file>
+                <rom-file id="06855"><area-name id="135"/></rom-file>
+            </category>
+        </category>
+        <category><name>&amp;<i18n-string id="FFXI3"/></name>
+            <category><name><region-name id="022"/></name>
+                <rom-file id="06732"><area-name id="012"/></rom-file>
+                <rom-file id="06733"><area-name id="013"/></rom-file>
+                <rom-file id="06731"><area-name id="011"/></rom-file>
+            </category>
+            <category><name><region-name id="023"/></name>
+                <rom-file id="06746"><area-name id="026"/></rom-file>
+            </category>
+            <category><name><region-name id="024"/></name>
+                <rom-file id="06744"><area-name id="024"/></rom-file>
+                <rom-file id="06745"><area-name id="025"/></rom-file>
+                <rom-file id="06747"><area-name id="027"/></rom-file>
+                <rom-file id="06748"><area-name id="028"/></rom-file>
+                <rom-file id="06749"><area-name id="029"/></rom-file>
+                <rom-file id="06750"><area-name id="030"/></rom-file>
+                <rom-file id="06751"><area-name id="031"/></rom-file>
+                <rom-file id="06752"><area-name id="032"/></rom-file>
+            </category>
+            <category><name><region-name id="025"/></name>
+                <rom-file id="06734"><area-name id="014"/></rom-file>
+                <rom-file id="06738"><area-name id="018"/></rom-file>
+                <rom-file id="06736"><area-name id="016"/></rom-file>
+                <rom-file id="06740"><area-name id="020"/></rom-file>
+                <rom-file id="06742"><area-name id="022"/></rom-file>
+                <rom-file id="06739"><area-name id="019"/></rom-file>
+                <rom-file id="06737"><area-name id="017"/></rom-file>
+                <rom-file id="06741"><area-name id="021"/></rom-file>
+                <rom-file id="06743"><area-name id="023"/></rom-file>
+            </category>
+            <category><name><region-name id="026"/></name>
+                <rom-file id="06753"><area-name id="033"/></rom-file>
+                <rom-file id="06756"><area-name id="036"/></rom-file>
+                <rom-file id="06754"><area-name id="034"/></rom-file>
+                <rom-file id="06755"><area-name id="035"/></rom-file>
+            </category>
+            <category><name><region-name id="027"/></name>
+                <rom-file id="06758"><area-name id="038"/></rom-file>
+                <rom-file id="06757"><area-name id="037"/></rom-file>
+            </category>
+        </category>
+        <category><name>&amp;<i18n-string id="FFXI4"/></name>
+            <category><name><region-name id="028"/></name></category>
+            <category><name><region-name id="029"/></name>
+                <rom-file id="06770"><area-name id="050"/></rom-file>
+                <rom-file id="06768"><area-name id="048"/></rom-file>
+                <rom-file id="06772"><area-name id="052"/></rom-file>
+                <rom-file id="06790"><area-name id="070"/></rom-file>
+                <rom-file id="06791"><area-name id="071"/></rom-file>
+            </category>
+            <category><name><region-name id="030"/></name>
+                <rom-file id="06788"><area-name id="068"/></rom-file>
+                <rom-file id="06787"><area-name id="067"/></rom-file>
+                <rom-file id="06785"><area-name id="065"/></rom-file>
+                <rom-file id="06786"><area-name id="066"/></rom-file>
+                <rom-file id="06771"><area-name id="051"/></rom-file>
+            </category>
+            <category><name><region-name id="031"/></name>
+                <rom-file id="06782"><area-name id="062"/></rom-file>
+                <rom-file id="06783"><area-name id="063"/></rom-file>
+                <rom-file id="06781"><area-name id="061"/></rom-file>
+                <rom-file id="06784"><area-name id="064"/></rom-file>
+            </category>
+            <category><name><region-name id="032"/></name>
+                <rom-file id="06774"><area-name id="054"/></rom-file>
+                <rom-file id="06799"><area-name id="079"/></rom-file>
+                <rom-file id="06775"><area-name id="055"/></rom-file>
+                <rom-file id="06789"><area-name id="069"/></rom-file>
+                <rom-file id="06773"><area-name id="053"/></rom-file>
+                <rom-file id="06797"><area-name id="077"/></rom-file>
+                <rom-file id="06776"><area-name id="056"/></rom-file>
+                <rom-file id="06777"><area-name id="057"/></rom-file>
+                <rom-file id="06780"><area-name id="060"/></rom-file>
+            </category>
+            <category><name><region-name id="033"/></name>
+                <rom-file id="06792"><area-name id="072"/></rom-file>
+                <rom-file id="06794"><area-name id="074"/></rom-file>
+                <rom-file id="06795"><area-name id="075"/></rom-file>
+                <rom-file id="06798"><area-name id="078"/></rom-file>
+                <rom-file id="06796"><area-name id="076"/></rom-file>
+                <rom-file id="06793"><area-name id="073"/></rom-file>
+            </category>
+        </category>
+        <category><name>&amp;<i18n-string id="FFXI5"/></name>
+            <category><name><region-name id="034"/></name>
+                <rom-file id="06801"><area-name id="081"/></rom-file>
+                <rom-file id="06806"><area-name id="086"/></rom-file>
+                <rom-file id="06800"><area-name id="080"/></rom-file>
+            </category>
+            <category><name><region-name id="035"/></name>
+                <rom-file id="06804"><area-name id="084"/></rom-file>
+                <rom-file id="06802"><area-name id="082"/></rom-file>
+                <rom-file id="06805"><area-name id="085"/></rom-file>
+                <rom-file id="06895"><area-name id="175"/></rom-file>
+            </category>
+            <category><name><region-name id="036"/></name>
+                <rom-file id="06807"><area-name id="087"/></rom-file>
+                <rom-file id="06809"><area-name id="089"/></rom-file>
+                <rom-file id="06808"><area-name id="088"/></rom-file>
+                <rom-file id="06813"><area-name id="093"/></rom-file>
+            </category>
+            <category><name><region-name id="037"/></name>
+                <rom-file id="06812"><area-name id="092"/></rom-file>
+                <rom-file id="06891"><area-name id="171"/></rom-file>
+                <rom-file id="06810"><area-name id="090"/></rom-file>
+                <rom-file id="06811"><area-name id="091"/></rom-file>
+                <rom-file id="06803"><area-name id="083"/></rom-file>
+            </category>
+            <category><name><region-name id="038"/></name>
+                <rom-file id="06816"><area-name id="096"/></rom-file>
+                <rom-file id="06849"><area-name id="129"/></rom-file>
+                <rom-file id="06815"><area-name id="095"/></rom-file>
+                <rom-file id="06814"><area-name id="094"/></rom-file>
+            </category>
+            <category><name><region-name id="039"/></name>
+                <rom-file id="06819"><area-name id="099"/></rom-file>
+                <rom-file id="06884"><area-name id="164"/></rom-file>
+                <rom-file id="06817"><area-name id="097"/></rom-file>
+                <rom-file id="06818"><area-name id="098"/></rom-file>
+            </category>
+            <category><name><region-name id="040"/></name>
+                <rom-file id="06856"><area-name id="136"/></rom-file>
+            </category>
+            <category><name><region-name id="041"/></name>
+                <rom-file id="06858"><area-name id="138"/></rom-file>
+                <rom-file id="06875"><area-name id="155"/></rom-file>
+                <rom-file id="06876"><area-name id="156"/></rom-file>
+                <rom-file id="06857"><area-name id="137"/></rom-file>
+            </category>
+            <category><name><region-name id="042"/></name>
+            </category>
+            <category><name><region-name id="043"/></name>
+            </category>
+            <category><name><region-name id="044"/></name>
+            </category>
+            <category><name><region-name id="045"/></name>
+            </category>
+            <category><name><region-name id="047"/></name>
+                <rom-file id="06902"><area-name id="182"/></rom-file>
+                <rom-file id="06942"><area-name id="222"/></rom-file>
+            </category>
+        </category>
+        <category><name><i18n-string id="Menu:Abyssea"/></name>
+            <rom-file id="06935"><area-name id="215"/></rom-file>
+            <rom-file id="06735"><area-name id="015"/></rom-file>
+            <rom-file id="06852"><area-name id="132"/></rom-file>
+            <rom-file id="06936"><area-name id="216"/></rom-file>
+            <rom-file id="06765"><area-name id="045"/></rom-file>
+            <rom-file id="06937"><area-name id="217"/></rom-file>
+            <rom-file id="06938"><area-name id="218"/></rom-file>
+            <rom-file id="06973"><area-name id="253"/></rom-file>
+            <rom-file id="06974"><area-name id="254"/></rom-file>
+            <rom-file id="06975"><area-name id="255"/></rom-file>
+        </category>
+        <category><name>&amp;<i18n-string id="FFXI9"/></name>
+            <category><name><region-name id="049"/></name>
+                <rom-file id="86491"><area-name id="256"/></rom-file>
+                <rom-file id="86492"><area-name id="257"/></rom-file>
+                <rom-file id="86493"><area-name id="258"/></rom-file>
+                <rom-file id="86494"><area-name id="259"/></rom-file>
+            </category>
+            <category><name><region-name id="050"/></name>
+                <rom-file id="86495"><area-name id="260"/></rom-file>
+                <rom-file id="86496"><area-name id="261"/></rom-file>
+                <rom-file id="86497"><area-name id="262"/></rom-file>
+                <rom-file id="86498"><area-name id="263"/></rom-file>
+                <rom-file id="86499"><area-name id="264"/></rom-file>
+                <rom-file id="86500"><area-name id="265"/></rom-file>
+                <rom-file id="86501"><area-name id="266"/></rom-file>
+                <rom-file id="86502"><area-name id="267"/></rom-file>
+                <rom-file id="86503"><area-name id="268"/></rom-file>
+                <rom-file id="86504"><area-name id="269"/></rom-file>
+                <rom-file id="86505"><area-name id="270"/></rom-file>
+                <rom-file id="86506"><area-name id="271"/></rom-file>
+                <rom-file id="86507"><area-name id="272"/></rom-file>
+                <rom-file id="86508"><area-name id="273"/></rom-file>
+                <rom-file id="86509"><area-name id="274"/></rom-file>
+                <rom-file id="86510"><area-name id="275"/></rom-file>
+                <rom-file id="86511"><area-name id="276"/></rom-file>
+                <rom-file id="86512"><area-name id="277"/></rom-file>
+                <rom-file id="86519"><area-name id="284"/></rom-file>
+                <rom-file id="86515"><area-name id="280"/></rom-file>
+            </category>
+        </category>
+        <category><name><i18n-string id="Rhapsodies of Vana'diel"/></name>
+        <!-- NOTE: For some reason "Menu:" kept showing up in the menu..Even though existing entries were formatted that way.. -->
+            <rom-file id="86523"><area-name id="288"/></rom-file>
+            <rom-file id="86524"><area-name id="289"/></rom-file>
+        </category>
+        <category><name><i18n-string id="Menu:Other"/></name>
+            <category><name><i18n-string id="Menu:MoblinMaze"/></name>
+                <rom-file id="67911"><i18n-string id="Menu:SanitizationAlpha"/></rom-file>
+                <rom-file id="67912"><i18n-string id="Menu:SanitizationBeta"/></rom-file>
+                <rom-file id="67913"><i18n-string id="Menu:SanitizationGamma"/></rom-file>
+                <rom-file id="67914"><i18n-string id="Menu:Materialization"/></rom-file>
+                <rom-file id="67915"><i18n-string id="Menu:Actualization"/></rom-file>
+                <rom-file id="67916"><i18n-string id="Menu:Appropriation"/></rom-file>
+                <rom-file id="67917"><i18n-string id="Menu:Liquidation"/></rom-file>
+                <rom-file id="67918"><i18n-string id="Menu:AquaticDepopulation"/></rom-file>
+                <rom-file id="67919"><i18n-string id="Menu:Revitalization"/></rom-file>
+            </category>
+            <category><name><i18n-string id="Menu:MeebleBurrows"/></name>
+                <rom-file id="67920"><i18n-string id="Menu:Adjunct"/></rom-file>
+                <rom-file id="67921"><i18n-string id="Menu:Assistant"/></rom-file>
+                <rom-file id="67922"><i18n-string id="Menu:Instructor"/></rom-file>
+                <rom-file id="67923"><i18n-string id="Menu:AssociateResearcher"/></rom-file>
+                <rom-file id="67924"><i18n-string id="Menu:Researcher"/></rom-file>
+                <rom-file id="67925"><i18n-string id="Menu:BAdjunct"/></rom-file>
+                <rom-file id="67926"><i18n-string id="Menu:BAssistant"/></rom-file>
+                <rom-file id="67927"><i18n-string id="Menu:BInstructor"/></rom-file>
+            </category>
+            <separator/>
+            <rom-file id="06944"><area-name id="224"/></rom-file>
+            <rom-file id="06946"><area-name id="226"/></rom-file>
+            <rom-file id="06943"><area-name id="223"/></rom-file>
+            <rom-file id="06945"><area-name id="225"/></rom-file>
+            <separator/>
+            <rom-file id="06941"><area-name id="221"/></rom-file>
+            <rom-file id="06948"><area-name id="228"/> <i18n-string id="Menu:WithPirates"/></rom-file>
+            <rom-file id="06940"><area-name id="220"/></rom-file>
+            <rom-file id="06947"><area-name id="227"/> <i18n-string id="Menu:WithPirates"/></rom-file>
+            <separator/>
+            <rom-file id="06766"><area-name id="046"/></rom-file>
+            <rom-file id="06767"><area-name id="047"/></rom-file>
+            <rom-file id="06778"><area-name id="058"/></rom-file>
+            <rom-file id="06779"><area-name id="059"/></rom-file>
+            <separator/>
+            <rom-file id="06763"><area-name id="043"/></rom-file>
+            <rom-file id="06764"><area-name id="044"/></rom-file>
+            <rom-file id="06903"><area-name id="183"/></rom-file>
+            <separator/>
+            <rom-file id="86520"><area-name id="285"/></rom-file>
+            <separator/>
+            <!-- NOTE: <area-name id="210"/> won't do because in the client this is blank, but leaked official documentation names it "GM Home" -->
+            <rom-file id="06930">GM Home</rom-file>
+        </category>
     </category>
-  </category>
-  <category><name><i18n-string id="Menu:Images"/></name>
-    <category><name><i18n-string id="Menu:Maps"/></name>
-      <category><name>&amp;<i18n-string id="FFXI1"/></name>
-	<category><name><region-name id="000"/></name>
-	  <category><name><region-name id="000"/></name>
-	    <rom-file id="05505"><i18n-string id="Menu:Highlight"/><area-name id="233"/></rom-file>
-	    <rom-file id="05503"><i18n-string id="Menu:Highlight"/><area-name id="231"/></rom-file>
-	    <rom-file id="05504"><i18n-string id="Menu:Highlight"/><area-name id="232"/></rom-file>
-	    <rom-file id="05480"><i18n-string id="Menu:Highlight"/><area-name id="230"/></rom-file>
-	  </category>
-	  <rom-file id="05479"><area-name id="233"/></rom-file>
-	  <rom-file id="05477"><area-name id="231"/></rom-file>
-	  <rom-file id="05478"><area-name id="232"/></rom-file>
-	  <rom-file id="05476"><area-name id="230"/></rom-file>
-	</category>
-	<category><name><region-name id="001"/></name>
-	  <category><name><region-name id="001"/></name>
-	    <rom-file id="05485"><i18n-string id="Menu:Highlight"/><area-name id="234"/></rom-file>
-	    <rom-file id="05506"><i18n-string id="Menu:Highlight"/><area-name id="235"/></rom-file>
-	    <rom-file id="05507"><i18n-string id="Menu:Highlight"/><area-name id="236"/></rom-file>
-	    <rom-file id="05508"><i18n-string id="Menu:Highlight"/><area-name id="237"/></rom-file>
-	  </category>
-	  <rom-file id="05481"><area-name id="234"/></rom-file>
-	  <rom-file id="05482"><area-name id="235"/></rom-file>
-	  <rom-file id="05483"><area-name id="236"/></rom-file>
-	  <rom-file id="05484"><area-name id="237"/></rom-file>
-	</category>
-	<category><name><region-name id="002"/></name>
-	  <category><name><region-name id="002"/></name>
-	    <rom-file id="05491"><i18n-string id="Menu:Highlight"/><area-name id="238"/></rom-file>
-	    <rom-file id="05509"><i18n-string id="Menu:Highlight"/><area-name id="239"/></rom-file>
-	    <rom-file id="05510"><i18n-string id="Menu:Highlight"/><area-name id="240"/></rom-file>
-	    <rom-file id="05511"><i18n-string id="Menu:Highlight"/><area-name id="241"/></rom-file>
-	  </category>
-	  <category><name><area-name id="238"/></name>
-	    <rom-file id="05486"><i18n-string id="Menu:Full"/></rom-file>
-	    <rom-file id="05501"><i18n-string id="Menu:NorthHalf"/></rom-file>
-	    <rom-file id="05502"><i18n-string id="Menu:SouthHalf"/></rom-file>
-	  </category>
-	  <rom-file id="05487"><area-name id="239"/></rom-file>
-	  <rom-file id="05488"><area-name id="240"/></rom-file>
-	  <rom-file id="05489"><area-name id="241"/></rom-file>
-	</category>
-	<category><name><region-name id="003"/></name>
-	  <category><name><region-name id="003"/></name>
-	    <rom-file id="05496"><i18n-string id="Menu:Highlight"/><area-name id="243"/></rom-file>
-	    <rom-file id="05512"><i18n-string id="Menu:Highlight"/><area-name id="244"/></rom-file>
-	    <rom-file id="05513"><i18n-string id="Menu:Highlight"/><area-name id="245"/></rom-file>
-	    <rom-file id="05514"><i18n-string id="Menu:Highlight"/><area-name id="246"/></rom-file>
-	  </category>
-	  <rom-file id="05492"><area-name id="243"/></rom-file>
-	  <rom-file id="05493"><area-name id="244"/></rom-file>
-	  <rom-file id="05494"><area-name id="245"/></rom-file>
-	  <rom-file id="05495"><area-name id="246"/></rom-file>
-	</category>
-	<category><name><region-name id="004"/></name>
-	  <category><name><area-name id="167"/></name>
-	    <rom-file id="05401"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="05402"><i18n-string id="Menu:MapN"/>2</rom-file>
-	    <rom-file id="05403"><i18n-string id="Menu:MapN"/>3</rom-file>
-	  </category>
-	  <rom-file id="05314"><area-name id="101"/></rom-file>
-	  <category><name><area-name id="140"/></name>
-	    <rom-file id="05340"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="05341"><i18n-string id="Menu:MapN"/>2</rom-file>
-	  </category>
-	  <rom-file id="05342"><area-name id="141"/></rom-file>
-	  <category><name><area-name id="190"/></name>
-	    <rom-file id="05425"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="05428"><i18n-string id="Menu:MapN"/>2</rom-file>
-	    <rom-file id="05429"><i18n-string id="Menu:MapN"/>3</rom-file>
-	    <rom-file id="05430"><i18n-string id="Menu:MapN"/>4</rom-file>
-	  </category>
-	  <rom-file id="05313"><area-name id="100"/></rom-file>
-	  <category><name><area-name id="142"/></name>
-	    <rom-file id="05343"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="05529"><i18n-string id="Menu:MapN"/>2</rom-file>
-	    <rom-file id="05530"><i18n-string id="Menu:MapN"/>3</rom-file>
-	  </category>
-	</category>
-	<category><name><region-name id="005"/></name>
-	  <category><name><area-name id="196"/></name>
-	    <rom-file id="05443"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="05444"><i18n-string id="Menu:MapN"/>2</rom-file>
-	    <rom-file id="05445"><i18n-string id="Menu:MapN"/>3</rom-file>
-	    <rom-file id="05446"><i18n-string id="Menu:MapN"/>4</rom-file>
-	    <rom-file id="05534"><i18n-string id="Menu:MapN"/>5</rom-file>
-	  </category>
-	  <rom-file id="05315"><area-name id="102"/></rom-file>
-	  <rom-file id="05321"><area-name id="108"/></rom-file>
-	  <category><name><area-name id="193"/></name>
-	    <rom-file id="05437"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="05438"><i18n-string id="Menu:MapN"/>2</rom-file>
-	    <rom-file id="05439"><i18n-string id="Menu:MapN"/>3</rom-file>
-	    <rom-file id="05531"><i18n-string id="Menu:MapN"/>4</rom-file>
-	  </category>
-	  <rom-file id="05497"><area-name id="248"/></rom-file>
-	  <rom-file id="05316"><area-name id="103"/></rom-file>
-	</category>
-	<category><name><region-name id="006"/></name>
-	  <rom-file id="05318"><area-name id="105"/></rom-file>
-	  <category><name><area-name id="002"/></name>
-	    <rom-file id="05689"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="05742"><i18n-string id="Menu:MapN"/>2</rom-file>
-	    <rom-file id="05742"><i18n-string id="Menu:MapN"/>3</rom-file>
-	  </category>
-	  <rom-file id="05355"><area-name id="149"/></rom-file>
-	  <rom-file id="05317"><area-name id="104"/></rom-file>
-	  <rom-file id="05356"><area-name id="150"/></rom-file>
-	  <rom-file id="05744"><area-name id="001"/></rom-file>
-	  <category><name><area-name id="195"/></name>
-	    <rom-file id="05440"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="05441"><i18n-string id="Menu:MapN"/>2</rom-file>
-	    <rom-file id="05442"><i18n-string id="Menu:MapN"/>3</rom-file>
-	    <rom-file id="05533"><i18n-string id="Menu:MapN"/>4</rom-file>
-	  </category>
-	</category>
-	<category><name><region-name id="007"/></name>
-	  <category><name><area-name id="191"/></name>
-	    <rom-file id="05426"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="05427"><i18n-string id="Menu:MapN"/>2</rom-file>
-	    <rom-file id="05431"><i18n-string id="Menu:MapN"/>3</rom-file>
-	  </category>
-	  <category><name><area-name id="173"/></name>
-	    <rom-file id="05410"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="05634"><i18n-string id="Menu:MapN"/>2</rom-file>
-	    <rom-file id="05635"><i18n-string id="Menu:MapN"/>3</rom-file>
-	    <rom-file id="05636"><i18n-string id="Menu:MapN"/>4</rom-file>
-	    <rom-file id="05637"><i18n-string id="Menu:MapN"/>5</rom-file>
-	    <rom-file id="05638"><i18n-string id="Menu:MapN"/>6</rom-file>
-	  </category>
-	  <rom-file id="05319"><area-name id="106"/></rom-file>
-	  <category><name><area-name id="143"/></name>
-	    <rom-file id="05344"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="05345"><i18n-string id="Menu:MapN"/>2</rom-file>
-	    <rom-file id="05346"><i18n-string id="Menu:MapN"/>3</rom-file>
-	  </category>
-	  <rom-file id="05320"><area-name id="107"/></rom-file>
-	  <rom-file id="05409"><area-name id="172"/></rom-file>
-	</category>
-	<category><name><region-name id="008"/></name>
-	  <category><name><area-name id="147"/></name>
-	    <rom-file id="05351"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="05352"><i18n-string id="Menu:MapN"/>2</rom-file>
-	  </category>
-	  <category><name><area-name id="197"/></name>
-	    <rom-file id="05447"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="05448"><i18n-string id="Menu:MapN"/>2</rom-file>
-	    <rom-file id="05528"><i18n-string id="Menu:MapN"/>3</rom-file>
-	    <rom-file id="05535"><i18n-string id="Menu:MapN"/>4</rom-file>
-	  </category>
-	  <rom-file id="05322"><area-name id="109"/></rom-file>
-	  <rom-file id="05354"><area-name id="148"/></rom-file>
-	  <rom-file id="05323"><area-name id="110"/></rom-file>
-	</category>
-	<category><name><region-name id="009"/></name>
-	  <rom-file id="05329"><area-name id="116"/></rom-file>
-	  <category><name><area-name id="145"/></name>
-	    <rom-file id="05348"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="05349"><i18n-string id="Menu:MapN"/>2</rom-file>
-	  </category>
-	  <category><name>Horutoto Ruins</name>
-	    <category><name>Amaryllis Tower</name>
-	      <rom-file id="05432"><i18n-string id="Menu:MapN"/>1</rom-file>
-	      <rom-file id="05467"><i18n-string id="Menu:MapN"/>2</rom-file>
-	      <rom-file id="05532"><i18n-string id="Menu:MapN"/>3</rom-file>
-	    </category>
-	    <rom-file id="05462">Beetle's Burrow</rom-file>
-	    <rom-file id="05436">Dahlia Tower</rom-file>
-	    <rom-file id="05433">Lilac Tower</rom-file>
-	    <rom-file id="05435">Lily Tower</rom-file>
-	    <rom-file id="05434">Marguerite Tower</rom-file>
-	    <category><name>Rose Tower</name>
-	      <rom-file id="05463"><i18n-string id="Menu:MapN"/>1</rom-file>
-	      <rom-file id="05466"><i18n-string id="Menu:MapN"/>2</rom-file>
-	    </category>
-	  </category>
-	  <category><name><area-name id="169"/></name>
-	    <rom-file id="05406"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="05465"><i18n-string id="Menu:MapN"/>2</rom-file>
-	    <rom-file id="05633"><i18n-string id="Menu:MapN"/>3</rom-file>
-	  </category>
-	  <rom-file id="05328"><area-name id="115"/></rom-file>
-	</category>
-	<category><name><region-name id="010"/></name>
-	  <category><name><area-name id="004"/></name>
-	    <rom-file id="05690">Mainland</rom-file>
-	    <rom-file id="05691">Purgonorgo Isle</rom-file>
-	  </category>
-	  <rom-file id="05331"><area-name id="118"/></rom-file>
-	  <rom-file id="05679"><area-name id="213"/></rom-file>
-	  <rom-file id="05745"><area-name id="003"/></rom-file>
-	  <category><name><area-name id="198"/></name>
-	    <rom-file id="05449"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="05450"><i18n-string id="Menu:MapN"/>2</rom-file>
-	    <rom-file id="05536"><i18n-string id="Menu:MapN"/>3</rom-file>
-	  </category>
-	  <rom-file id="05498"><area-name id="249"/></rom-file>
-	  <rom-file id="05330"><area-name id="117"/></rom-file>
-	</category>
-	<category><name><region-name id="011"/></name>
-	  <rom-file id="05361"><area-name id="152"/></rom-file>
-	  <rom-file id="05693"><area-name id="007"/></rom-file>
-	  <category><name><area-name id="151"/></name>
-	    <rom-file id="05357"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="05358"><i18n-string id="Menu:MapN"/>2</rom-file>
-	    <rom-file id="05359"><i18n-string id="Menu:MapN"/>3</rom-file>
-	    <rom-file id="05360"><i18n-string id="Menu:MapN"/>4</rom-file>
-	    <rom-file id="05464"><i18n-string id="Menu:MapN"/>5</rom-file>
-	    <rom-file id="05468"><i18n-string id="Menu:MapN"/>6</rom-file>
-	    <rom-file id="05469"><i18n-string id="Menu:MapN"/>7</rom-file>
-	  </category>
-	  <category><name><area-name id="200"/></name>
-	    <rom-file id="05451"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="05459"><i18n-string id="Menu:MapN"/>2</rom-file>
-	    <rom-file id="05460"><i18n-string id="Menu:MapN"/>3</rom-file>
-	    <rom-file id="05461"><i18n-string id="Menu:MapN"/>4</rom-file>
-	    <rom-file id="05537"><i18n-string id="Menu:MapN"/>5</rom-file>
-	  </category>
-	  <rom-file id="05332"><area-name id="119"/></rom-file>
-	  <rom-file id="05333"><area-name id="120"/></rom-file>
-	</category>
-	<category><name><region-name id="012"/></name>
-	  <rom-file id="05324"><area-name id="111"/></rom-file>
-	  <category><name><area-name id="204"/></name>
-	    <rom-file id="05454"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="05455"><i18n-string id="Menu:MapN"/>2</rom-file>
-	    <rom-file id="05538"><i18n-string id="Menu:MapN"/>3</rom-file>
-	  </category>
-	  <category><name><area-name id="009"/></name>
-	    <rom-file id="05694"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="05695"><i18n-string id="Menu:MapN"/>2</rom-file>
-	    <rom-file id="05696"><i18n-string id="Menu:MapN"/>3</rom-file>
-	    <rom-file id="05697"><i18n-string id="Menu:MapN"/>4</rom-file>
-	    <rom-file id="05698"><i18n-string id="Menu:MapN"/>5</rom-file>
-	    <rom-file id="05699"><i18n-string id="Menu:MapN"/>6</rom-file>
-	    <rom-file id="05700"><i18n-string id="Menu:MapN"/>7</rom-file>
-	    <rom-file id="05701"><i18n-string id="Menu:MapN"/>8</rom-file>
-	    <rom-file id="05702"><i18n-string id="Menu:MapN"/>9</rom-file>
-	    <rom-file id="05703"><i18n-string id="Menu:MapN"/>10</rom-file>
-	    <rom-file id="05704"><i18n-string id="Menu:MapN"/>11</rom-file>
-	    <rom-file id="05705"><i18n-string id="Menu:MapN"/>12</rom-file>
-	    <rom-file id="05706"><i18n-string id="Menu:MapN"/>13</rom-file>
-	    <rom-file id="05707"><i18n-string id="Menu:MapN"/>14</rom-file>
-	    <rom-file id="05708"><i18n-string id="Menu:MapN"/>15</rom-file>
-	    <rom-file id="05709"><i18n-string id="Menu:MapN"/>16</rom-file>
-	  </category>
-	  <rom-file id="05400"><area-name id="166"/></rom-file>
-	</category>
-	<category><name><region-name id="013"/></name>
-	  <category><name><area-name id="161"/></name>
-	    <rom-file id="05390"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="05515"><i18n-string id="Menu:MapN"/>2</rom-file>
-	    <rom-file id="05516"><i18n-string id="Menu:MapN"/>3</rom-file>
-	    <rom-file id="05517"><i18n-string id="Menu:MapN"/>4</rom-file>
-	  </category>
-	  <category><name><area-name id="162"/></name>
-	    <rom-file id="05396"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="05397"><i18n-string id="Menu:MapN"/>2</rom-file>
-	    <rom-file id="05398"><i18n-string id="Menu:MapN"/>3</rom-file>
-	    <rom-file id="05399"><i18n-string id="Menu:MapN"/>4</rom-file>
-	    <rom-file id="05524"><i18n-string id="Menu:MapN"/>5</rom-file>
-	    <rom-file id="05525"><i18n-string id="Menu:MapN"/>6</rom-file>
-	    <rom-file id="05526"><i18n-string id="Menu:MapN"/>7</rom-file>
-	    <rom-file id="05527"><i18n-string id="Menu:MapN"/>8</rom-file>
-	  </category>
-	  <rom-file id="05692"><area-name id="005"/></rom-file>
-	  <rom-file id="05325"><area-name id="112"/></rom-file>
-	</category>
-	<category><name><region-name id="014"/></name>
-	  <rom-file id="05337"><area-name id="127"/></rom-file>
-	  <category><name>Delkfutt's Tower</name>
-	    <rom-file id="05385">Basement</rom-file>
-	    <rom-file id="05373">First Floor</rom-file>
-	    <rom-file id="05374">Second Floor</rom-file>
-	    <rom-file id="05375">Third Floor</rom-file>
-	    <rom-file id="05376">Fourth Floor</rom-file>
-	    <rom-file id="05377">Fifth Floor</rom-file>
-	    <rom-file id="05378">Sixth Floor</rom-file>
-	    <rom-file id="05379">Seventh Floor</rom-file>
-	    <rom-file id="05380">Eighth Floor</rom-file>
-	    <rom-file id="05381">Ninth Floor</rom-file>
-	    <rom-file id="05382">Tenth Floor</rom-file>
-	    <rom-file id="05383">Eleventh Floor</rom-file>
-	    <rom-file id="05384">Twelfth Floor</rom-file>
-	    <rom-file id="05518">Hidden Elevator 1</rom-file>
-	    <rom-file id="05519">Hidden Elevator 2</rom-file>
-	    <rom-file id="05520">Hidden Elevator 3</rom-file>
-	  </category>
-	  <rom-file id="05336"><area-name id="126"/></rom-file>
-	</category>
-      </category>
-      <category><name>&amp;<i18n-string id="FFXI2"/></name>
-	<category><name><region-name id="015"/></name>
-	  <rom-file id="05619"><area-name id="154"/></rom-file>
-	  <rom-file id="05683"><area-name id="251"/></rom-file>
-	  <rom-file id="05609"><area-name id="122"/></rom-file>
-	  <category><name><area-name id="153"/></name>
-	    <rom-file id="05615"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="05616"><i18n-string id="Menu:MapN"/>2</rom-file>
-	    <rom-file id="05617"><i18n-string id="Menu:MapN"/>3</rom-file>
-	    <rom-file id="05618"><i18n-string id="Menu:MapN"/>4</rom-file>
-	  </category>
-	  <rom-file id="05608"><area-name id="121"/></rom-file>
-	</category>
-	<category><name><region-name id="016"/></name>
-	  <rom-file id="05607"><area-name id="114"/></rom-file>
-	  <category><name><area-name id="208"/></name>
-	    <rom-file id="05671"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="05672"><i18n-string id="Menu:MapN"/>2</rom-file>
-	    <rom-file id="05673"><i18n-string id="Menu:MapN"/>3</rom-file>
-	    <rom-file id="05674"><i18n-string id="Menu:MapN"/>4</rom-file>
-	    <rom-file id="05675"><i18n-string id="Menu:MapN"/>5</rom-file>
-	    <rom-file id="05676"><i18n-string id="Menu:MapN"/>6</rom-file>
-	    <rom-file id="05686"><i18n-string id="Menu:MapN"/>7</rom-file>
-	    <rom-file id="05687"><i18n-string id="Menu:MapN"/>8</rom-file>
-	  </category>
-	  <rom-file id="05681"><area-name id="247"/></rom-file>
-	  <rom-file id="05612"><area-name id="125"/></rom-file>
-	</category>
-	<category><name><region-name id="017"/></name>
-	  <rom-file id="05606"><area-name id="113"/></rom-file>
-	  <category><name><area-name id="212"/></name>
-	    <rom-file id="05677"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="05678"><i18n-string id="Menu:MapN"/>2</rom-file>
-	  </category>
-	  <category><name><area-name id="174"/></name>
-	    <rom-file id="05411"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="05639"><i18n-string id="Menu:MapN"/>2</rom-file>
-	    <rom-file id="05640"><i18n-string id="Menu:MapN"/>3</rom-file>
-	    <rom-file id="05641"><i18n-string id="Menu:MapN"/>4</rom-file>
-	    <rom-file id="05642"><i18n-string id="Menu:MapN"/>5</rom-file>
-	  </category>
-	  <rom-file id="05613"><area-name id="128"/></rom-file>
-	</category>
-	<category><name><region-name id="018"/></name>
-	  <rom-file id="05682"><area-name id="250"/></rom-file>
-	  <rom-file id="05684"><area-name id="252"/></rom-file>
-	  <category><name><area-name id="176"/></name>
-	    <rom-file id="05643"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="05644"><i18n-string id="Menu:MapN"/>2</rom-file>
-	    <rom-file id="05645"><i18n-string id="Menu:MapN"/>3</rom-file>
-	    <rom-file id="05646"><i18n-string id="Menu:MapN"/>4</rom-file>
-	    <rom-file id="05647"><i18n-string id="Menu:MapN"/>5</rom-file>
-	  </category>
-	  <category><name>The Cavern Of Flames</name>
-	    <rom-file id="05456"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="05457"><i18n-string id="Menu:MapN"/>2</rom-file>
-	  </category>
-	  <rom-file id="05610"><area-name id="123"/></rom-file>
-	</category>
-	<category><name><region-name id="019"/></name>
-	  <category><name><area-name id="160"/></name>
-	    <rom-file id="05624"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="05625"><i18n-string id="Menu:MapN"/>2</rom-file>
-	    <rom-file id="05626"><i18n-string id="Menu:MapN"/>3</rom-file>
-	    <rom-file id="05627"><i18n-string id="Menu:MapN"/>4</rom-file>
-	    <rom-file id="05628"><i18n-string id="Menu:MapN"/>5</rom-file>
-	    <rom-file id="05629"><i18n-string id="Menu:MapN"/>6</rom-file>
-	    <rom-file id="05630"><i18n-string id="Menu:MapN"/>7</rom-file>
-	    <rom-file id="05631"><i18n-string id="Menu:MapN"/>8</rom-file>
-	    <rom-file id="05632"><i18n-string id="Menu:MapN"/>9</rom-file>
-	  </category>
-	  <category><name><area-name id="205"/></name>
-	    <rom-file id="05663"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="05664"><i18n-string id="Menu:MapN"/>2</rom-file>
-	    <rom-file id="05665"><i18n-string id="Menu:MapN"/>3</rom-file>
-	    <rom-file id="05666"><i18n-string id="Menu:MapN"/>4</rom-file>
-	    <rom-file id="05667"><i18n-string id="Menu:MapN"/>5</rom-file>
-	    <rom-file id="05668"><i18n-string id="Menu:MapN"/>6</rom-file>
-	    <rom-file id="05669"><i18n-string id="Menu:MapN"/>7</rom-file>
-	    <rom-file id="05670"><i18n-string id="Menu:MapN"/>8</rom-file>
-	    <rom-file id="05685"><i18n-string id="Menu:MapN"/>9</rom-file>
-	  </category>
-	  <category><name><area-name id="159"/></name>
-	    <rom-file id="05620"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="05621"><i18n-string id="Menu:MapN"/>2</rom-file>
-	    <rom-file id="05622"><i18n-string id="Menu:MapN"/>3</rom-file>
-	    <rom-file id="05623"><i18n-string id="Menu:MapN"/>4</rom-file>
-	  </category>
-	  <rom-file id="05611"><area-name id="124"/></rom-file>
-	</category>
-	<category><name><region-name id="020"/></name>
-	  <rom-file id="05614"><area-name id="130"/></rom-file>
-	  <category><name><area-name id="178"/></name>
-	    <rom-file id="05657"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="05658"><i18n-string id="Menu:MapN"/>2</rom-file>
-	    <rom-file id="05659"><i18n-string id="Menu:MapN"/>3</rom-file>
-	    <rom-file id="05660"><i18n-string id="Menu:MapN"/>4</rom-file>
-	    <rom-file id="05661"><i18n-string id="Menu:MapN"/>5</rom-file>
-	    <rom-file id="05662"><i18n-string id="Menu:MapN"/>6</rom-file>
-	  </category>
-	  <category><name><area-name id="177"/></name>
-	    <rom-file id="05648"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="05649"><i18n-string id="Menu:MapN"/>2</rom-file>
-	    <rom-file id="05650"><i18n-string id="Menu:MapN"/>3</rom-file>
-	    <rom-file id="05651"><i18n-string id="Menu:MapN"/>4</rom-file>
-	    <rom-file id="05652"><i18n-string id="Menu:MapN"/>5</rom-file>
-	    <rom-file id="05653"><i18n-string id="Menu:MapN"/>6</rom-file>
-	    <rom-file id="05654"><i18n-string id="Menu:MapN"/>7</rom-file>
-	    <rom-file id="05655"><i18n-string id="Menu:MapN"/>8</rom-file>
-	    <rom-file id="05656"><i18n-string id="Menu:MapN"/>9</rom-file>
-	  </category>
-	</category>
-	<category><name><region-name id="021"/></name></category>
-      </category>
-      <category><name>&amp;<i18n-string id="FFXI3"/></name>
-	<category><name><region-name id="022"/></name>
-	  <rom-file id="05710"><area-name id="011"/></rom-file>
-	  <rom-file id="05711"><area-name id="012"/></rom-file>
-	</category>
-	<category><name><region-name id="023"/></name>
-	  <category><name><area-name id="026"/></name>
-	    <rom-file id="05721"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="05722"><i18n-string id="Menu:MapN"/>2</rom-file>
-	    <rom-file id="05723"><i18n-string id="Menu:MapN"/>3</rom-file>
-	  </category>
-	</category>
-	<category><name><region-name id="024"/></name>
-	  <category><name><area-name id="044"/></name>
-	    <rom-file id="05747"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="05748"><i18n-string id="Menu:MapN"/>2</rom-file>
-	  </category>
-	  <rom-file id="05746"><area-name id="043"/></rom-file>
-	  <rom-file id="05719"><area-name id="024"/></rom-file>
-	  <rom-file id="05719"><area-name id="025"/></rom-file>
-	  <category><name><area-name id="027"/></name>
-	    <rom-file id="05724"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="05725"><i18n-string id="Menu:MapN"/>2</rom-file>
-	    <rom-file id="05739"><i18n-string id="Menu:MapN"/>3</rom-file>
-	  </category>
-	  <category><name><area-name id="030"/></name>
-	    <rom-file id="05730"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="05731"><i18n-string id="Menu:MapN"/>2</rom-file>
-	  </category>
-	  <category><name><area-name id="029"/></name>
-	    <rom-file id="05728"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="05729"><i18n-string id="Menu:MapN"/>2</rom-file>
-	  </category>
-	  <category><name><area-name id="028"/></name>
-	    <rom-file id="05726"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="05727"><i18n-string id="Menu:MapN"/>2</rom-file>
-	  </category>
-	  <rom-file id="05740"><area-name id="032"/></rom-file>
-	</category>
-	<category><name><region-name id="025"/></name>
-	  <rom-file id="05713"><area-name id="014"/> (<area-name id="018"/>?)</rom-file>
-	  <rom-file id="05712"><area-name id="014"/> (<area-name id="016"/>?)</rom-file>
-	  <rom-file id="05714"><area-name id="014"/> (<area-name id="020"/>?)</rom-file>
-	  <rom-file id="05716"><area-name id="018"/></rom-file>
-	  <rom-file id="05715"><area-name id="016"/></rom-file>
-	  <rom-file id="05717"><area-name id="020"/></rom-file>
-	  <rom-file id="05718"><area-name id="022"/></rom-file>
-	</category>
-	<category><name><region-name id="026"/></name>
-	  <rom-file id="05732"><area-name id="033"/></rom-file>
-	  <category><name><area-name id="034"/></name>
-	    <rom-file id="05733"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="05734"><i18n-string id="Menu:MapN"/>2</rom-file>
-	    <rom-file id="05741"><i18n-string id="Menu:MapN"/>3</rom-file>
-	  </category>
-	  <category><name><area-name id="035"/></name>
-	    <rom-file id="05735"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="05736"><i18n-string id="Menu:MapN"/>2</rom-file>
-	    <rom-file id="05737"><i18n-string id="Menu:MapN"/>3</rom-file>
-	    <rom-file id="05738"><i18n-string id="Menu:MapN"/>4</rom-file>
-	  </category>
-	</category>
-	<category><name><region-name id="027"/></name></category>
-      </category>
-      <category><name>&amp;<i18n-string id="FFXI4"/></name>
-	<category><name><region-name id="028"/></name></category>
-	<category><name><region-name id="029"/></name>
-	  <rom-file id="53298"><area-name id="050"/></rom-file>
-	  <rom-file id="53297"><area-name id="048"/></rom-file>
-	  <category><name><area-name id="052"/></name>
-	    <rom-file id="53300"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="53301"><i18n-string id="Menu:MapN"/>2</rom-file>
-	  </category>
-	  <category><name><area-name id="070"/></name>
-	    <rom-file id="53370"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="53371"><i18n-string id="Menu:MapN"/>2</rom-file>
-	    <rom-file id="53372"><i18n-string id="Menu:MapN"/>3</rom-file>
-	    <rom-file id="53373"><i18n-string id="Menu:MapN"/>4</rom-file>
-	    <rom-file id="53374"><i18n-string id="Menu:MapN"/>5</rom-file>
-	    <rom-file id="53375"><i18n-string id="Menu:MapN"/>6</rom-file>
-	    <rom-file id="53376"><i18n-string id="Menu:MapN"/>7</rom-file>
-	  </category>
-	  <category><name><area-name id="071"/></name>
-	    <rom-file id="53377"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="53378"><i18n-string id="Menu:MapN"/>2</rom-file>
-	  </category>
-	</category>
-	<category><name><region-name id="030"/></name>
-	  <category><name><area-name id="068"/></name>
-	    <rom-file id="53353"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="53354"><i18n-string id="Menu:MapN"/>2</rom-file>
-	    <rom-file id="53355"><i18n-string id="Menu:MapN"/>3</rom-file>
-	    <rom-file id="53356"><i18n-string id="Menu:MapN"/>4</rom-file>
-	    <rom-file id="53357"><i18n-string id="Menu:MapN"/>5</rom-file>
-	    <rom-file id="53358"><i18n-string id="Menu:MapN"/>6</rom-file>
-	    <rom-file id="53359"><i18n-string id="Menu:MapN"/>7</rom-file>
-	  </category>
-	  <category><name><area-name id="065"/></name>
-	    <rom-file id="53341"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="53342"><i18n-string id="Menu:MapN"/>2</rom-file>
-	    <rom-file id="53406"><i18n-string id="Menu:MapN"/>3</rom-file>
-	  </category>
-	  <category><name><area-name id="066"/></name>
-	    <rom-file id="53343"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="53344"><i18n-string id="Menu:MapN"/>2</rom-file>
-	    <rom-file id="53345"><i18n-string id="Menu:MapN"/>3</rom-file>
-	    <rom-file id="53346"><i18n-string id="Menu:MapN"/>4</rom-file>
-	    <rom-file id="53347"><i18n-string id="Menu:MapN"/>5</rom-file>
-	    <rom-file id="53348"><i18n-string id="Menu:MapN"/>6</rom-file>
-	    <rom-file id="53349"><i18n-string id="Menu:MapN"/>7</rom-file>
-	    <rom-file id="53350"><i18n-string id="Menu:MapN"/>8</rom-file>
-	    <rom-file id="53351"><i18n-string id="Menu:MapN"/>9</rom-file>
-	    <rom-file id="53352"><i18n-string id="Menu:MapN"/>10</rom-file>
-	  </category>
-	  <rom-file id="53299"><area-name id="051"/></rom-file>
-	</category>
-	<category><name><region-name id="031"/></name>
-	  <category><name><area-name id="062"/></name>
-	    <rom-file id="53329"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="53330"><i18n-string id="Menu:MapN"/>2</rom-file>
-	    <rom-file id="53407"><i18n-string id="Menu:MapN"/>3</rom-file>
-	    <rom-file id="53415"><i18n-string id="Menu:MapN"/>4</rom-file>
-	  </category>
-	  <category><name><area-name id="063"/></name>
-	    <rom-file id="53331"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="53332"><i18n-string id="Menu:MapN"/>2</rom-file>
-	    <rom-file id="53333"><i18n-string id="Menu:MapN"/>3</rom-file>
-	    <rom-file id="53334"><i18n-string id="Menu:MapN"/>4</rom-file>
-	    <rom-file id="53335"><i18n-string id="Menu:MapN"/>5</rom-file>
-	    <rom-file id="53336"><i18n-string id="Menu:MapN"/>6</rom-file>
-	    <rom-file id="53337"><i18n-string id="Menu:MapN"/>7</rom-file>
-	    <rom-file id="53338"><i18n-string id="Menu:MapN"/>8</rom-file>
-	    <rom-file id="53339"><i18n-string id="Menu:MapN"/>9</rom-file>
-	    <rom-file id="53340"><i18n-string id="Menu:MapN"/>10</rom-file>
-	  </category>
-	  <rom-file id="53328"><area-name id="061"/></rom-file>
-	</category>
-	<category><name><region-name id="032"/></name>
-	  <category><name><area-name id="054"/></name>
-	    <rom-file id="53303"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="53304"><i18n-string id="Menu:MapN"/>2</rom-file>
-	    <rom-file id="53305"><i18n-string id="Menu:MapN"/>3</rom-file>
-	    <rom-file id="53398"><i18n-string id="Menu:MapN"/>4</rom-file>
-	    <rom-file id="53399"><i18n-string id="Menu:MapN"/>5</rom-file>
-	    <rom-file id="53400"><i18n-string id="Menu:MapN"/>6</rom-file>
-	    <rom-file id="53401"><i18n-string id="Menu:MapN"/>7</rom-file>
-	    <rom-file id="53402"><i18n-string id="Menu:MapN"/>8</rom-file>
-	    <rom-file id="53403"><i18n-string id="Menu:MapN"/>9</rom-file>
-	    <rom-file id="53404"><i18n-string id="Menu:MapN"/>10</rom-file>
-	    <rom-file id="53405"><i18n-string id="Menu:MapN"/>11</rom-file>
-	  </category>
-	  <category><name><area-name id="079"/></name>
-	    <rom-file id="53394"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="53395"><i18n-string id="Menu:MapN"/>2</rom-file>
-	    <rom-file id="53396"><i18n-string id="Menu:MapN"/>3</rom-file>
-	    <rom-file id="53397"><i18n-string id="Menu:MapN"/>4</rom-file>
-	  </category>
-	  <category><name><area-name id="055"/></name>
-	    <rom-file id="53306"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="53307"><i18n-string id="Menu:MapN"/>2</rom-file>
-	    <rom-file id="53308"><i18n-string id="Menu:MapN"/>3</rom-file>
-	    <rom-file id="53309"><i18n-string id="Menu:MapN"/>4</rom-file>
-	    <rom-file id="53310"><i18n-string id="Menu:MapN"/>5</rom-file>
-	    <rom-file id="53311"><i18n-string id="Menu:MapN"/>6</rom-file>
-	    <rom-file id="53312"><i18n-string id="Menu:MapN"/>7</rom-file>
-	    <rom-file id="53313"><i18n-string id="Menu:MapN"/>8</rom-file>
-	    <rom-file id="53314"><i18n-string id="Menu:MapN"/>9</rom-file>
-	    <rom-file id="53315"><i18n-string id="Menu:MapN"/>10</rom-file>
-	  </category>
-	  <category><name><area-name id="069"/></name>
-	    <rom-file id="53360"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="53361"><i18n-string id="Menu:MapN"/>2</rom-file>
-	    <rom-file id="53362"><i18n-string id="Menu:MapN"/>3</rom-file>
-	    <rom-file id="53363"><i18n-string id="Menu:MapN"/>4</rom-file>
-	    <rom-file id="53364"><i18n-string id="Menu:MapN"/>5</rom-file>
-	    <rom-file id="53365"><i18n-string id="Menu:MapN"/>6</rom-file>
-	    <rom-file id="53366"><i18n-string id="Menu:MapN"/>7</rom-file>
-	    <rom-file id="53367"><i18n-string id="Menu:MapN"/>8</rom-file>
-	    <rom-file id="53368"><i18n-string id="Menu:MapN"/>9</rom-file>
-	    <rom-file id="53369"><i18n-string id="Menu:MapN"/>10</rom-file>
-	  </category>
-	  <rom-file id="53302"><area-name id="053"/></rom-file>
-	  <category><name><area-name id="077"/></name>
-	    <rom-file id="53384"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="53385"><i18n-string id="Menu:MapN"/>2</rom-file>
-	    <rom-file id="53386"><i18n-string id="Menu:MapN"/>3</rom-file>
-	    <rom-file id="53387"><i18n-string id="Menu:MapN"/>4</rom-file>
-	    <rom-file id="53388"><i18n-string id="Menu:MapN"/>5</rom-file>
-	    <rom-file id="53389"><i18n-string id="Menu:MapN"/>6</rom-file>
-	    <rom-file id="53390"><i18n-string id="Menu:MapN"/>7</rom-file>
-	    <rom-file id="53391"><i18n-string id="Menu:MapN"/>8</rom-file>
-	  </category>
-	  <category><name><area-name id="056"/></name>
-	    <rom-file id="53316"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="53317"><i18n-string id="Menu:MapN"/>2</rom-file>
-	    <rom-file id="53318"><i18n-string id="Menu:MapN"/>3</rom-file>
-	    <rom-file id="53319"><i18n-string id="Menu:MapN"/>4</rom-file>
-	    <rom-file id="53320"><i18n-string id="Menu:MapN"/>5</rom-file>
-	    <rom-file id="53321"><i18n-string id="Menu:MapN"/>6</rom-file>
-	    <rom-file id="53322"><i18n-string id="Menu:MapN"/>7</rom-file>
-	    <rom-file id="53323"><i18n-string id="Menu:MapN"/>8</rom-file>
-	    <rom-file id="53324"><i18n-string id="Menu:MapN"/>9</rom-file>
-	    <rom-file id="53325"><i18n-string id="Menu:MapN"/>10</rom-file>
-	  </category>
-	</category>
-	<category><name><region-name id="033"/></name>
-	  <category><name><area-name id="072"/></name>
-	    <rom-file id="53379"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="53380"><i18n-string id="Menu:MapN"/>2</rom-file>
-	    <rom-file id="53381"><i18n-string id="Menu:MapN"/>3</rom-file>
-	    <rom-file id="53382"><i18n-string id="Menu:MapN"/>4</rom-file>
-	    <rom-file id="53383"><i18n-string id="Menu:MapN"/>5</rom-file>
-	    <rom-file id="53408"><i18n-string id="Menu:MapN"/>6</rom-file>
-	    <rom-file id="53409"><i18n-string id="Menu:MapN"/>7</rom-file>
-	    <rom-file id="53410"><i18n-string id="Menu:MapN"/>8</rom-file>
-	    <rom-file id="53411"><i18n-string id="Menu:MapN"/>9</rom-file>
-	    <rom-file id="53412"><i18n-string id="Menu:MapN"/>10</rom-file>
-	    <rom-file id="53413"><i18n-string id="Menu:MapN"/>11</rom-file>
-	    <rom-file id="53414"><i18n-string id="Menu:MapN"/>12</rom-file>
-	  </category>
-	  <category><name><area-name id="074"/></name>
-	    <rom-file id="53424"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="53425"><i18n-string id="Menu:MapN"/>2</rom-file>
-	    <rom-file id="53426"><i18n-string id="Menu:MapN"/>3</rom-file>
-	    <rom-file id="53427"><i18n-string id="Menu:MapN"/>4</rom-file>
-	    <rom-file id="53428"><i18n-string id="Menu:MapN"/>5</rom-file>
-	    <rom-file id="53429"><i18n-string id="Menu:MapN"/>6</rom-file>
-	    <rom-file id="53430"><i18n-string id="Menu:MapN"/>7</rom-file>
-	  </category>
-	  <category><name><area-name id="075"/></name>
-	    <rom-file id="53431"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="53432"><i18n-string id="Menu:MapN"/>2</rom-file>
-	    <rom-file id="53433"><i18n-string id="Menu:MapN"/>3</rom-file>
-	    <rom-file id="53434"><i18n-string id="Menu:MapN"/>4</rom-file>
-	    <rom-file id="53435"><i18n-string id="Menu:MapN"/>5</rom-file>
-	  </category>
-	  <category><name><area-name id="076"/></name>
-	    <rom-file id="53436"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="53437"><i18n-string id="Menu:MapN"/>2</rom-file>
-	    <rom-file id="53438"><i18n-string id="Menu:MapN"/>3</rom-file>
-	    <rom-file id="53439"><i18n-string id="Menu:MapN"/>4</rom-file>
-	    <rom-file id="53440"><i18n-string id="Menu:MapN"/>5</rom-file>
-	  </category>
-	  <category><name><area-name id="073"/></name>
-	    <rom-file id="53417"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="53418"><i18n-string id="Menu:MapN"/>2</rom-file>
-	    <rom-file id="53419"><i18n-string id="Menu:MapN"/>3</rom-file>
-	    <rom-file id="53420"><i18n-string id="Menu:MapN"/>4</rom-file>
-	    <rom-file id="53421"><i18n-string id="Menu:MapN"/>5</rom-file>
-	    <rom-file id="53422"><i18n-string id="Menu:MapN"/>6</rom-file>
-	    <rom-file id="53423"><i18n-string id="Menu:MapN"/>7</rom-file>
-	  </category>
-	</category>
-      </category>
-      <category><name>&amp;<i18n-string id="FFXI5"/></name>
-	<category><name><region-name id="034"/></name></category>
-	<category><name><region-name id="035"/></name></category>
-	<category><name><region-name id="036"/></name></category>
-	<category><name><region-name id="037"/></name></category>
-	<category><name><region-name id="038"/></name></category>
-	<category><name><region-name id="039"/></name></category>
-	<category><name><region-name id="040"/></name></category>
-	<category><name><region-name id="041"/></name></category>
-	<category><name><region-name id="042"/></name></category>
-	<category><name><region-name id="043"/></name></category>
-	<category><name><region-name id="044"/></name></category>
-	<category><name><region-name id="045"/></name></category>
-  <category><name><area-name id="086"/></name>
-    <rom-file id="53496"><i18n-string id="Menu:MapN"/>1</rom-file>
-    <rom-file id="53497"><i18n-string id="Menu:MapN"/>2</rom-file>
-    <rom-file id="53498"><i18n-string id="Menu:MapN"/>3</rom-file>
-    <rom-file id="53499"><i18n-string id="Menu:MapN"/>4</rom-file>
-    <rom-file id="53500"><i18n-string id="Menu:MapN"/>5</rom-file>
-    <rom-file id="53501"><i18n-string id="Menu:MapN"/>6</rom-file>
-    <rom-file id="53502"><i18n-string id="Menu:MapN"/>7</rom-file>
-    <rom-file id="53503"><i18n-string id="Menu:MapN"/>8</rom-file>
-    <rom-file id="53504"><i18n-string id="Menu:MapN"/>9</rom-file>
-    <rom-file id="53505"><i18n-string id="Menu:MapN"/>10</rom-file>
-    <rom-file id="53506"><i18n-string id="Menu:MapN"/>11</rom-file>
-    <rom-file id="53507"><i18n-string id="Menu:MapN"/>12</rom-file>
-    <rom-file id="53508"><i18n-string id="Menu:MapN"/>13</rom-file>
-    <rom-file id="53509"><i18n-string id="Menu:MapN"/>14</rom-file>
-    <rom-file id="53510"><i18n-string id="Menu:MapN"/>15</rom-file>
-    <rom-file id="53511"><i18n-string id="Menu:MapN"/>16</rom-file>
-    <rom-file id="53512"><i18n-string id="Menu:MapN"/>17</rom-file>
-    <rom-file id="53513"><i18n-string id="Menu:MapN"/>18</rom-file>
-  </category>
-  <category><name><area-name id="093"/></name>
-    <rom-file id="53514"><i18n-string id="Menu:MapN"/>1</rom-file>
-    <rom-file id="53515"><i18n-string id="Menu:MapN"/>2</rom-file>
-    <rom-file id="53516"><i18n-string id="Menu:MapN"/>3</rom-file>
-    <rom-file id="53517"><i18n-string id="Menu:MapN"/>4</rom-file>
-    <rom-file id="53518"><i18n-string id="Menu:MapN"/>5</rom-file>
-    <rom-file id="53519"><i18n-string id="Menu:MapN"/>6</rom-file>
-    <rom-file id="53520"><i18n-string id="Menu:MapN"/>7</rom-file>
-    <rom-file id="53521"><i18n-string id="Menu:MapN"/>8</rom-file>
-    <rom-file id="53522"><i18n-string id="Menu:MapN"/>9</rom-file>
-    <rom-file id="53523"><i18n-string id="Menu:MapN"/>10</rom-file>
-    <rom-file id="53524"><i18n-string id="Menu:MapN"/>11</rom-file>
-    <rom-file id="53525"><i18n-string id="Menu:MapN"/>12</rom-file>
-    <rom-file id="53526"><i18n-string id="Menu:MapN"/>13</rom-file>
-    <rom-file id="53527"><i18n-string id="Menu:MapN"/>14</rom-file>
-    <rom-file id="53528"><i18n-string id="Menu:MapN"/>15</rom-file>
-    <rom-file id="53529"><i18n-string id="Menu:MapN"/>16</rom-file>
-  </category>
-  <category><name><area-name id="129"/></name>
-    <rom-file id="53530"><i18n-string id="Menu:MapN"/>1</rom-file>
-    <rom-file id="53531"><i18n-string id="Menu:MapN"/>2</rom-file>
-    <rom-file id="53532"><i18n-string id="Menu:MapN"/>3</rom-file>
-    <rom-file id="53533"><i18n-string id="Menu:MapN"/>4</rom-file>
-    <rom-file id="53534"><i18n-string id="Menu:MapN"/>5</rom-file>
-    <rom-file id="53535"><i18n-string id="Menu:MapN"/>6</rom-file>
-    <rom-file id="53536"><i18n-string id="Menu:MapN"/>7</rom-file>
-    <rom-file id="53537"><i18n-string id="Menu:MapN"/>8</rom-file>
-    <rom-file id="53538"><i18n-string id="Menu:MapN"/>9</rom-file>
-    <rom-file id="53539"><i18n-string id="Menu:MapN"/>10</rom-file>
-    <rom-file id="53540"><i18n-string id="Menu:MapN"/>11</rom-file>
-    <rom-file id="53541"><i18n-string id="Menu:MapN"/>12</rom-file>
-    <rom-file id="53542"><i18n-string id="Menu:MapN"/>13</rom-file>
-    <rom-file id="53543"><i18n-string id="Menu:MapN"/>14</rom-file>
-    <rom-file id="53544"><i18n-string id="Menu:MapN"/>15</rom-file>
-    <rom-file id="53545"><i18n-string id="Menu:MapN"/>16</rom-file>
-    <rom-file id="53546"><i18n-string id="Menu:MapN"/>17</rom-file>
-    <rom-file id="53547"><i18n-string id="Menu:MapN"/>18</rom-file>
-  </category>
-      </category>
-      <category><name><i18n-string id="FFXI9"/></name>
-	<category><name><region-name id="049"/></name>
-	  <rom-file id="53570"><area-name id="256"/></rom-file>
-	  <rom-file id="53571"><area-name id="257"/></rom-file>
-	  <rom-file id="53572"><area-name id="258"/></rom-file>
-  <category><name><area-name id="259"/></name>
-    <rom-file id="53573"><i18n-string id="Menu:MapN"/>1</rom-file>
-    <rom-file id="53574"><i18n-string id="Menu:MapN"/>2</rom-file>
-    <rom-file id="53575"><i18n-string id="Menu:MapN"/>3</rom-file>
-    <rom-file id="53576"><i18n-string id="Menu:MapN"/>4</rom-file>
-    <rom-file id="53577"><i18n-string id="Menu:MapN"/>5</rom-file>
-    <rom-file id="53578"><i18n-string id="Menu:MapN"/>6</rom-file>
-    <rom-file id="53579"><i18n-string id="Menu:MapN"/>7</rom-file>
-    <rom-file id="53580"><i18n-string id="Menu:MapN"/>8</rom-file>
-    <rom-file id="53581"><i18n-string id="Menu:MapN"/>9</rom-file>
-    <rom-file id="53582"><i18n-string id="Menu:MapN"/>10</rom-file>
-    <rom-file id="53583"><i18n-string id="Menu:MapN"/>11</rom-file>
-    <rom-file id="53584"><i18n-string id="Menu:MapN"/>12</rom-file>
-    <rom-file id="53585"><i18n-string id="Menu:MapN"/>13</rom-file>
-    <rom-file id="53586"><i18n-string id="Menu:MapN"/>14</rom-file>
-    <rom-file id="53587"><i18n-string id="Menu:MapN"/>15</rom-file>
-  </category>  
-  </category>
-	<category><name><region-name id="050"/></name>
-	  <rom-file id="53588"><area-name id="260"/></rom-file>
-	  <rom-file id="53589"><area-name id="261"/></rom-file>
-	  <rom-file id="53590"><area-name id="262"/></rom-file>
-	  <rom-file id="53591"><area-name id="265"/></rom-file>
-  <category><name><area-name id="268"/></name>
-    <rom-file id="53592"><i18n-string id="Menu:MapN"/>1</rom-file>
-    <rom-file id="53593"><i18n-string id="Menu:MapN"/>2</rom-file>
-  </category>
-  <category><name><area-name id="269"/></name>
-    <rom-file id="53594"><i18n-string id="Menu:MapN"/>1</rom-file>
-    <rom-file id="53595"><i18n-string id="Menu:MapN"/>2</rom-file>
-  </category>
-       <rom-file id="53596"><area-name id="270"/></rom-file>
-    <category><name><area-name id="271"/></name>
-      <rom-file id="53597"><i18n-string id="Menu:MapN"/>1</rom-file>
-      <rom-file id="53598"><i18n-string id="Menu:MapN"/>2</rom-file>
-      <rom-file id="53599"><i18n-string id="Menu:MapN"/>3</rom-file>
-      <rom-file id="53600"><i18n-string id="Menu:MapN"/>4</rom-file>
-      <rom-file id="53601"><i18n-string id="Menu:MapN"/>5</rom-file>
-      <rom-file id="53602"><i18n-string id="Menu:MapN"/>6</rom-file>
-      <rom-file id="53603"><i18n-string id="Menu:MapN"/>7</rom-file>
-      <rom-file id="53604"><i18n-string id="Menu:MapN"/>8</rom-file>
-      <rom-file id="53605"><i18n-string id="Menu:MapN"/>9</rom-file>
-      <rom-file id="53606"><i18n-string id="Menu:MapN"/>10</rom-file>
-      <rom-file id="53607"><i18n-string id="Menu:MapN"/>11</rom-file>
-      <rom-file id="53608"><i18n-string id="Menu:MapN"/>12</rom-file>
-      <rom-file id="53609"><i18n-string id="Menu:MapN"/>13</rom-file>
-      <rom-file id="53610"><i18n-string id="Menu:MapN"/>14</rom-file>
-      <rom-file id="53611"><i18n-string id="Menu:MapN"/>15</rom-file>
-      <rom-file id="53612"><i18n-string id="Menu:MapN"/>16</rom-file>
-      <rom-file id="53613"><i18n-string id="Menu:MapN"/>17</rom-file>
-      <rom-file id="53614"><i18n-string id="Menu:MapN"/>18</rom-file>
-      <rom-file id="53615"><i18n-string id="Menu:MapN"/>19</rom-file>
-    </category> 
-       <rom-file id="53616"><area-name id="263"/></rom-file>
-    <category><name><area-name id="264"/></name>
-      <rom-file id="53617"><i18n-string id="Menu:MapN"/>1</rom-file>
-      <rom-file id="53618"><i18n-string id="Menu:MapN"/>2</rom-file> 
-      <rom-file id="53619"><i18n-string id="Menu:MapN"/>3</rom-file> 
-      <rom-file id="53620"><i18n-string id="Menu:MapN"/>4</rom-file>
-      <rom-file id="53621"><i18n-string id="Menu:MapN"/>5</rom-file>
-      <rom-file id="53622"><i18n-string id="Menu:MapN"/>6</rom-file>
-      <rom-file id="53623"><i18n-string id="Menu:MapN"/>7</rom-file>
-      <rom-file id="53624"><i18n-string id="Menu:MapN"/>8</rom-file>
-      <rom-file id="53625"><i18n-string id="Menu:MapN"/>9</rom-file>
-      <rom-file id="53626"><i18n-string id="Menu:MapN"/>10</rom-file>
-      <rom-file id="53627"><i18n-string id="Menu:MapN"/>11</rom-file>  
+    <category><name><i18n-string id="Menu:StringTables"/></name>
+        <category><name><i18n-string id="Menu:English"/></name>
+            <rom-file id="55701"><i18n-string id="Menu:AbilityNames"/></rom-file>
+            <rom-file id="55733"><i18n-string id="Menu:AbilityDescriptions"/></rom-file>
+            <rom-file id="55465"><i18n-string id="Menu:AreaNames"/></rom-file>
+            <rom-file id="55661"><i18n-string id="Menu:AreaNamesAlt"/></rom-file>
+            <rom-file id="55470"><i18n-string id="Menu:CharacterSelect"/></rom-file>
+            <rom-file id="55650"><i18n-string id="Menu:ChatFilterTypes"/></rom-file>
+            <rom-file id="55658"><i18n-string id="Menu:DayNames"/></rom-file>
+            <rom-file id="55659"><i18n-string id="Menu:Directions"/></rom-file>
+            <rom-file id="55471"><i18n-string id="Menu:EquipmentLocations"/></rom-file>
+            <rom-file id="55646"><i18n-string id="Menu:ErrorMessages"/></rom-file>
+            <rom-file id="55648"><i18n-string id="Menu:InGameMessages1"/></rom-file>
+            <rom-file id="55649"><i18n-string id="Menu:InGameMessages2"/></rom-file>
+            <rom-file id="55467"><i18n-string id="Menu:JobNames"/></rom-file>
+            <rom-file id="55695"><i18n-string id="Menu:KeyItems"/></rom-file><!-- alternative file IDs: 55696,55697,55698,55699,55700,55703,55705,55713,55714 -->
+            <rom-file id="55651"><i18n-string id="Menu:MenuItemDesc"/></rom-file>
+            <rom-file id="55652"><i18n-string id="Menu:MenuItemText"/></rom-file>
+            <category><name><i18n-string id="Menu:Missions"/></name>
+                <rom-file id="55715">San d'Oria</rom-file>
+                <rom-file id="55716">Bastok</rom-file>
+                <rom-file id="55717">Windurst</rom-file>
+                <rom-file id="55718">Zilart</rom-file>
+                <rom-file id="55719">Promathia</rom-file>
+                <rom-file id="55720">Assault</rom-file>
+                <rom-file id="55721">Aht Urhgan</rom-file>
+                <rom-file id="55723">Goddess</rom-file>
+                <rom-file id="55724">Campaign</rom-file>
+                <rom-file id="55738">Adoulin</rom-file>
+                <rom-file id="55740">Coalition</rom-file>
+                <rom-file id="55735">A Crystalline Prophecy</rom-file>
+                <rom-file id="55736">A Moogle Kupo d'Etat</rom-file>
+                <rom-file id="55737">A Shantotto Ascension</rom-file>
+            </category>
+            <rom-file id="55660"><i18n-string id="Menu:MoonPhases"/></rom-file>
+            <rom-file id="55647"><i18n-string id="Menu:POLMessages"/></rom-file>
+            <category><name><i18n-string id="Menu:Quests"/></name>
+                <rom-file id="55706">San d'Oria</rom-file>
+                <rom-file id="55707">Bastok</rom-file>
+                <rom-file id="55708">Windurst</rom-file>
+                <rom-file id="55709">Jeuno</rom-file>
+                <rom-file id="55710">Other</rom-file>
+                <rom-file id="55711">Zilart</rom-file>
+                <rom-file id="55712">Aht Urhgan</rom-file>
+                <rom-file id="55722">Goddess</rom-file>
+                <rom-file id="55739">Adoulin</rom-file>
+                <rom-file id="55713">Abyssea</rom-file>
+            </category>
+            <rom-file id="55469"><i18n-string id="Menu:RaceNames"/></rom-file>
+            <rom-file id="55654"><i18n-string id="Menu:RegionNames"/></rom-file>
+            <rom-file id="55702"><i18n-string id="Menu:SpellNames"/></rom-file>
+            <rom-file id="55734"><i18n-string id="Menu:SpellDescriptions"/></rom-file>
+            <rom-file id="00087"><i18n-string id="Menu:StatusInfo"/></rom-file>
+            <rom-file id="55725"><i18n-string id="Menu:StatusNames"/></rom-file><!-- alternative file IDs: 55726,55727,55728,55729,55730,55731,55732 -->
+            <rom-file id="00063"><i18n-string id="Menu:TimeAndPronouns"/></rom-file>
+            <rom-file id="55704"><i18n-string id="Menu:Titles"/></rom-file>
+            <rom-file id="55645"><i18n-string id="Menu:Various1"/></rom-file>
+            <rom-file id="55653"><i18n-string id="Menu:Various2"/></rom-file>
+            <rom-file id="55657"><i18n-string id="Menu:WeatherTypes"/></rom-file>
+        </category>
+        <category><name><i18n-string id="Menu:French"/></name>
+            <rom-file id="56241"><i18n-string id="Menu:AbilityNames"/></rom-file>
+            <rom-file id="56273"><i18n-string id="Menu:AbilityDescriptions"/></rom-file>
+            <rom-file id="56195"><i18n-string id="Menu:AreaNames"/></rom-file>
+            <rom-file id="56225"><i18n-string id="Menu:BlueMagicHelp"/></rom-file>
+            <rom-file id="56202"><i18n-string id="Menu:CharacterSelect"/></rom-file>
+            <rom-file id="56190"><i18n-string id="Menu:ChatFilterTypes"/></rom-file>
+            <rom-file id="56198"><i18n-string id="Menu:DayNames"/></rom-file>
+            <rom-file id="56199"><i18n-string id="Menu:Directions"/></rom-file>
+            <rom-file id="56206"><i18n-string id="Menu:EquipmentLocations"/></rom-file>
+            <rom-file id="56186"><i18n-string id="Menu:ErrorMessages"/></rom-file>
+            <rom-file id="56188"><i18n-string id="Menu:InGameMessages1"/></rom-file>
+            <rom-file id="56189"><i18n-string id="Menu:InGameMessages2"/></rom-file>
+            <rom-file id="56196"><i18n-string id="Menu:JobNames"/></rom-file>
+            <rom-file id="56245"><i18n-string id="Menu:KeyItems"/></rom-file><!-- alternative file IDs: 56253,56254 -->
+            <rom-file id="56191"><i18n-string id="Menu:MenuItemDesc"/></rom-file>
+            <rom-file id="56192"><i18n-string id="Menu:MenuItemText"/></rom-file>
+            <rom-file id="56226"><i18n-string id="Menu:MeripoHelp"/></rom-file>
+            <category><name><i18n-string id="Menu:Missions"/></name>
+                <rom-file id="56255">San d'Oria</rom-file>
+                <rom-file id="56256">Bastok</rom-file>
+                <rom-file id="56257">Windurst</rom-file>
+                <rom-file id="56258">Zilart</rom-file>
+                <rom-file id="56259">Promathia</rom-file>
+                <rom-file id="56260">Assault</rom-file>
+                <rom-file id="56261">Aht Urhgan</rom-file>
+                <rom-file id="56263">Goddess</rom-file>
+                <rom-file id="56264">Campaign</rom-file>
+                <rom-file id="56275">A Crystalline Prophecy</rom-file>
+                <rom-file id="56276">A Moogle Kupo d'Etat</rom-file>
+                <rom-file id="56277">A Shantotto Ascension</rom-file>
+            </category>
+            <rom-file id="56200"><i18n-string id="Menu:MoonPhases"/></rom-file>
+            <rom-file id="56187"><i18n-string id="Menu:POLMessages"/></rom-file>
+            <category><name><i18n-string id="Menu:Quests"/></name>
+                <rom-file id="56246">San d'Oria</rom-file>
+                <rom-file id="56247">Bastok</rom-file>
+                <rom-file id="56248">Windurst</rom-file>
+                <rom-file id="56249">Jeuno</rom-file>
+                <rom-file id="56250">Other</rom-file>
+                <rom-file id="56251">Zilart</rom-file>
+                <rom-file id="56252">Aht Urhgan</rom-file>
+                <rom-file id="56262">Goddess</rom-file>
+                <rom-file id="56253">Abyssea</rom-file>
+            </category>
+            <rom-file id="56203"><i18n-string id="Menu:RaceNames"/></rom-file>
+            <rom-file id="56194"><i18n-string id="Menu:RegionNames"/></rom-file>
+            <rom-file id="56242"><i18n-string id="Menu:SpellNames"/></rom-file>
+            <rom-file id="56274"><i18n-string id="Menu:SpellDescriptions"/></rom-file>
+            <rom-file id="56243"><i18n-string id="Menu:StatusInfo"/></rom-file>
+            <rom-file id="56272"><i18n-string id="Menu:StatusNames"/></rom-file>
+            <!--<rom-file id="00045"><i18n-string id="Menu:TimeAndPronouns"/></rom-file>-->
+            <rom-file id="56244"><i18n-string id="Menu:Titles"/></rom-file>
+            <rom-file id="56185"><i18n-string id="Menu:Various1"/></rom-file>
+            <rom-file id="56193"><i18n-string id="Menu:Various2"/></rom-file>
+            <rom-file id="56197"><i18n-string id="Menu:WeatherTypes"/></rom-file>
+        </category>
+        <category><name><i18n-string id="Menu:German"/></name>
+            <rom-file id="55821"><i18n-string id="Menu:AbilityNames"/></rom-file>
+            <rom-file id="55853"><i18n-string id="Menu:AbilityDescriptions"/></rom-file>
+            <rom-file id="55775"><i18n-string id="Menu:AreaNames"/></rom-file><!-- also: 55781 -->
+            <rom-file id="55805"><i18n-string id="Menu:BlueMagicHelp"/></rom-file>
+            <rom-file id="55782"><i18n-string id="Menu:CharacterSelect"/></rom-file>
+            <rom-file id="55770"><i18n-string id="Menu:ChatFilterTypes"/></rom-file>
+            <rom-file id="55778"><i18n-string id="Menu:DayNames"/></rom-file>
+            <rom-file id="55779"><i18n-string id="Menu:Directions"/></rom-file>
+            <rom-file id="55786"><i18n-string id="Menu:EquipmentLocations"/></rom-file>
+            <rom-file id="55766"><i18n-string id="Menu:ErrorMessages"/></rom-file>
+            <rom-file id="55768"><i18n-string id="Menu:InGameMessages1"/></rom-file>
+            <rom-file id="55769"><i18n-string id="Menu:InGameMessages2"/></rom-file>
+            <rom-file id="55776"><i18n-string id="Menu:JobNames"/></rom-file>
+            <rom-file id="55825"><i18n-string id="Menu:KeyItems"/></rom-file>
+            <rom-file id="55806"><i18n-string id="Menu:MeripoHelp"/></rom-file>
+            <rom-file id="55771"><i18n-string id="Menu:MenuItemDesc"/></rom-file>
+            <rom-file id="55772"><i18n-string id="Menu:MenuItemText"/></rom-file>
+            <category><name><i18n-string id="Menu:Missions"/></name>
+                <rom-file id="55835">San d'Oria</rom-file>
+                <rom-file id="55836">Bastok</rom-file>
+                <rom-file id="55837">Windurst</rom-file>
+                <rom-file id="55838">Zilart</rom-file>
+                <rom-file id="55839">Promathia</rom-file>
+                <rom-file id="55840">Assault</rom-file>
+                <rom-file id="55841">Aht Urhgan</rom-file>
+                <rom-file id="55843">Goddess</rom-file>
+                <rom-file id="55844">Campaign</rom-file>
+                <rom-file id="55855">A Crystalline Prophecy</rom-file>
+                <rom-file id="55856">A Moogle Kupo d'Etat</rom-file>
+                <rom-file id="55857">A Shantotto Ascension</rom-file>
+            </category>
+            <rom-file id="55780"><i18n-string id="Menu:MoonPhases"/></rom-file>
+            <rom-file id="55767"><i18n-string id="Menu:POLMessages"/></rom-file>
+            <category><name><i18n-string id="Menu:Quests"/></name>
+                <rom-file id="55826">San d'Oria</rom-file>
+                <rom-file id="55827">Bastok</rom-file>
+                <rom-file id="55828">Windurst</rom-file>
+                <rom-file id="55829">Jeuno</rom-file>
+                <rom-file id="55830">Other</rom-file>
+                <rom-file id="55831">Zilart</rom-file>
+                <rom-file id="55832">Aht Urhgan</rom-file>
+                <rom-file id="55842">Goddess</rom-file>
+                <rom-file id="55833">Abyssea</rom-file>
+            </category>
+            <rom-file id="55783"><i18n-string id="Menu:RaceNames"/></rom-file>
+            <rom-file id="55774"><i18n-string id="Menu:RegionNames"/></rom-file>
+            <rom-file id="55822"><i18n-string id="Menu:SpellNames"/></rom-file>
+            <rom-file id="55854"><i18n-string id="Menu:SpellDescriptions"/></rom-file>
+            <rom-file id="55823"><i18n-string id="Menu:StatusInfo"/></rom-file>
+            <rom-file id="55852"><i18n-string id="Menu:StatusNames"/></rom-file>
+            <!--<rom-file id="00045"><i18n-string id="Menu:TimeAndPronouns"/></rom-file>-->
+            <rom-file id="55824"><i18n-string id="Menu:Titles"/></rom-file>
+            <rom-file id="55765"><i18n-string id="Menu:Various1"/></rom-file>
+            <rom-file id="55773"><i18n-string id="Menu:Various2"/></rom-file>
+            <rom-file id="55777"><i18n-string id="Menu:WeatherTypes"/></rom-file>
+        </category>
+        <category><name><i18n-string id="Menu:Japanese"/></name>
+            <rom-file id="55581"><i18n-string id="Menu:AbilityNames"/></rom-file>
+            <rom-file id="55613"><i18n-string id="Menu:AbilityDescriptions"/></rom-file>
+            <rom-file id="55535"><i18n-string id="Menu:AreaNames"/></rom-file>
+            <rom-file id="55530"><i18n-string id="Menu:ChatFilterTypes"/></rom-file>
+            <rom-file id="55538"><i18n-string id="Menu:DayNames"/></rom-file>
+            <rom-file id="55539"><i18n-string id="Menu:Directions"/></rom-file>
+            <rom-file id="55526"><i18n-string id="Menu:ErrorMessages"/></rom-file>
+            <rom-file id="55528"><i18n-string id="Menu:InGameMessages1"/></rom-file>
+            <rom-file id="55529"><i18n-string id="Menu:InGameMessages2"/></rom-file>
+            <rom-file id="55536"><i18n-string id="Menu:JobNames"/></rom-file>
+            <rom-file id="55575"><i18n-string id="Menu:KeyItems"/></rom-file><!-- alternative file IDs: 55576,55577,55578,55579,55580,55583,55585,55593,55594 -->
+            <rom-file id="55531"><i18n-string id="Menu:MenuItemDesc"/></rom-file>
+            <rom-file id="55532"><i18n-string id="Menu:MenuItemText"/></rom-file>
+            <category><name><i18n-string id="Menu:Missions"/></name>
+                <rom-file id="55595">San d'Oria</rom-file>
+                <rom-file id="55596">Bastok</rom-file>
+                <rom-file id="55597">Windurst</rom-file>
+                <rom-file id="55598">Zilart</rom-file>
+                <rom-file id="55599">Promathia</rom-file>
+                <rom-file id="55600">Assault</rom-file>
+                <rom-file id="55601">Aht Urhgan</rom-file>
+                <rom-file id="55603">Goddess</rom-file>
+                <rom-file id="55604">Campaign</rom-file>
+                <rom-file id="55615">A Crystalline Prophecy</rom-file>
+                <rom-file id="55616">A Moogle Kupo d'Etat</rom-file>
+                <rom-file id="55617">A Shantotto Ascension</rom-file>
+            </category>
+            <rom-file id="55540"><i18n-string id="Menu:MoonPhases"/></rom-file>
+            <rom-file id="55527"><i18n-string id="Menu:POLMessages"/></rom-file>
+            <category><name><i18n-string id="Menu:Quests"/></name>
+                <rom-file id="55586">San d'Oria</rom-file>
+                <rom-file id="55587">Bastok</rom-file>
+                <rom-file id="55588">Windurst</rom-file>
+                <rom-file id="55589">Jeuno</rom-file>
+                <rom-file id="55590">Other</rom-file>
+                <rom-file id="55591">Zilart</rom-file>
+                <rom-file id="55592">Aht Urhgan</rom-file>
+                <rom-file id="55602">Goddess</rom-file>
+                <rom-file id="55593">Abyssea</rom-file>
+            </category>
+            <rom-file id="55534"><i18n-string id="Menu:RegionNames"/></rom-file>
+            <rom-file id="55582"><i18n-string id="Menu:SpellNames"/></rom-file>
+            <rom-file id="55614"><i18n-string id="Menu:SpellDescriptions"/></rom-file>
+            <rom-file id="00012"><i18n-string id="Menu:StatusInfo"/></rom-file>
+            <rom-file id="55605"><i18n-string id="Menu:StatusNames"/></rom-file><!-- alternative file IDs: 55606,55607,55608,55609,55610,55611,55612 -->
+            <rom-file id="00045"><i18n-string id="Menu:TimeAndPronouns"/></rom-file>
+            <rom-file id="55584"><i18n-string id="Menu:Titles"/></rom-file>
+            <rom-file id="55525"><i18n-string id="Menu:Various1"/></rom-file>
+            <rom-file id="55533"><i18n-string id="Menu:Various2"/></rom-file>
+            <rom-file id="55537"><i18n-string id="Menu:WeatherTypes"/></rom-file>
+        </category>
+        <category><name><i18n-string id="Menu:Common"/></name>
+            <rom-file id="55466"><i18n-string id="Menu:AreaNamesShort"/></rom-file>
+            <rom-file id="55468"><i18n-string id="Menu:JobNamesShort"/></rom-file>
+            <rom-file id="00081"><i18n-string id="Menu:Spells"/> &amp;&amp; <i18n-string id="Menu:Abilities"/></rom-file>
+            <rom-file id="00011"><i18n-string id="Menu:Spells"/> (Old, Stale)</rom-file>
+            <rom-file id="00086"><i18n-string id="Menu:Spells"/> (Even Older)</rom-file>
+        </category>
     </category>
-      <rom-file id="53628"><area-name id="266"/></rom-file> 
-    <category><name><area-name id="272"/></name>
-      <rom-file id="53629"><i18n-string id="Menu:MapN"/>1</rom-file> 
-      <rom-file id="53630"><i18n-string id="Menu:MapN"/>2</rom-file> 
-    </category>
-      <rom-file id="53631"><area-name id="267"/></rom-file>
-    <category><name><area-name id="273"/></name> 
-      <rom-file id="53632"><i18n-string id="Menu:MapN"/>1</rom-file>
-      <rom-file id="53633"><i18n-string id="Menu:MapN"/>2</rom-file>
-    </category>
-    <category><name><area-name id="274"/></name> 
-      <rom-file id="53635"><i18n-string id="Menu:MapN"/>1</rom-file>
-      <rom-file id="53636"><i18n-string id="Menu:MapN"/>2</rom-file>
-    </category>
-    <category><name><area-name id="275"/></name> 
-      <rom-file id="53637"><i18n-string id="Menu:MapN"/>1</rom-file>
-      <rom-file id="53638"><i18n-string id="Menu:MapN"/>2</rom-file>
-      <rom-file id="53639"><i18n-string id="Menu:MapN"/>3</rom-file>
-      <rom-file id="53640"><i18n-string id="Menu:MapN"/>4</rom-file>
-      <rom-file id="53641"><i18n-string id="Menu:MapN"/>5</rom-file>
-      <rom-file id="53642"><i18n-string id="Menu:MapN"/>6</rom-file>
-      <rom-file id="53643"><i18n-string id="Menu:MapN"/>7</rom-file>
-      <rom-file id="53644"><i18n-string id="Menu:MapN"/>8</rom-file>
-      <rom-file id="53645"><i18n-string id="Menu:MapN"/>9</rom-file>
-      <rom-file id="53646"><i18n-string id="Menu:MapN"/>10</rom-file>
-      <rom-file id="53647"><i18n-string id="Menu:MapN"/>11</rom-file>
-      <rom-file id="53648"><i18n-string id="Menu:MapN"/>12</rom-file>
-      <rom-file id="53649"><i18n-string id="Menu:MapN"/>13</rom-file>
-      <rom-file id="53650"><i18n-string id="Menu:MapN"/>14</rom-file>
-      <rom-file id="53651"><i18n-string id="Menu:MapN"/>15</rom-file>
-      <rom-file id="53652"><i18n-string id="Menu:MapN"/>16</rom-file>
-    </category>
-  </category>
-      </category>
-      <category><name><i18n-string id="Menu:Abyssea"/></name>
-	  <rom-file id="53548"><area-name id="015"/></rom-file>
-	  <rom-file id="53549"><area-name id="045"/></rom-file>
-	  <rom-file id="53550"><area-name id="132"/></rom-file>
-	  <rom-file id="53551"><area-name id="215"/></rom-file>
-	  <rom-file id="53552"><area-name id="216"/></rom-file>
-	  <rom-file id="53553"><area-name id="217"/></rom-file>
-	  <rom-file id="53554"><area-name id="218"/></rom-file>
-	  <rom-file id="53555"><area-name id="253"/></rom-file>
-	  <rom-file id="53556"><area-name id="254"/></rom-file>
-      </category>
-      <category><name><i18n-string id="Menu:Dynamis"/></name>
-	  <rom-file id="53557"><area-name id="185"/></rom-file>
-	  <rom-file id="53558"><area-name id="186"/></rom-file>
-	  <rom-file id="53559"><area-name id="187"/></rom-file>
-	  <rom-file id="53560"><area-name id="188"/></rom-file>
-	  <rom-file id="53561"><area-name id="134"/></rom-file>
-	  <rom-file id="53562"><area-name id="135"/></rom-file>
-	  <rom-file id="53563"><area-name id="039"/></rom-file>
-	  <rom-file id="53564"><area-name id="040"/></rom-file>
-	  <rom-file id="53565"><area-name id="041"/></rom-file>
-	  <category><name><area-name id="042"/></name>
-	    <rom-file id="53566"><i18n-string id="Menu:MapN"/>1</rom-file>
-	    <rom-file id="53567"><i18n-string id="Menu:MapN"/>2</rom-file>
-	    <rom-file id="53568"><i18n-string id="Menu:MapN"/>3</rom-file>
-	  </category>
-      </category>
-      <category><name><i18n-string id="Menu:Other"/></name>
-	<rom-file id="53416">Besieged Map</rom-file>
-	<rom-file id="05312">Conquest Map</rom-file>
-	<rom-file id="05541">Creature Chart</rom-file>
-	<!-- Also: 0/17/38,45,46,49,64,75-82,97-100,102-106,115,116,118,119,123-127 and 0/18/0-7,35,36,58,73,82,83 -->
-	<rom-file id="05326">Dummy Map</rom-file>
-	<rom-file id="05540">Element Chart</rom-file>
-	<!-- Also: 0/17/61,73,74; 0/18/41,105,106; 3/4/44,45 -->
-	<rom-file id="05339">No Map</rom-file>
-	<!-- Also: 0/17/83 -->
-	<rom-file id="05347">No Map (Alternate)</rom-file>
-	<rom-file id="05539">Stellar Map</rom-file>
-        <category><name><i18n-string id="Menu:TransportRoutes"/></name>
-	  <rom-file id="05473"><area-name id="224"/></rom-file>
-	  <rom-file id="05680"><area-name id="226"/></rom-file>
-	  <rom-file id="05472"><area-name id="223"/></rom-file>
-	  <rom-file id="05474"><area-name id="225"/></rom-file>
-	  <separator/>
-	  <rom-file id="05471"><area-name id="220"/></rom-file>
-	  <rom-file id="05470"><area-name id="221"/></rom-file>
-	  <separator/>
-	  <rom-file id="53295"><area-name id="046"/></rom-file>
-	  <rom-file id="53296"><area-name id="047"/></rom-file>
-	  <rom-file id="53326"><area-name id="058"/></rom-file>
-	  <rom-file id="53327"><area-name id="059"/></rom-file>
-	</category>
-      </category>
-    </category>
-    <category><name><i18n-string id="Menu:Other"/></name>
-      <rom-file id="00001"><i18n-string id="Menu:FontsAndMenus"/></rom-file>
-      <rom-file id="05112"><i18n-string id="Menu:RankBastok"/></rom-file><!-- alternative file IDs: 5113 -->
-      <rom-file id="05128"><i18n-string id="Menu:RankWindurst"/></rom-file>
-      <rom-file id="05144"><i18n-string id="Menu:RankSandOria"/></rom-file>
-      <category><name><i18n-string id="Menu:UIWindows"/></name>
-	<rom-file id="00014"><i18n-string id="Menu:StyleN"/>1</rom-file>
-	<rom-file id="00015"><i18n-string id="Menu:StyleN"/>2</rom-file>
-	<rom-file id="00016"><i18n-string id="Menu:StyleN"/>3</rom-file>
-	<rom-file id="00017"><i18n-string id="Menu:StyleN"/>4</rom-file>
-	<rom-file id="00018"><i18n-string id="Menu:StyleN"/>5</rom-file>
-	<rom-file id="00019"><i18n-string id="Menu:StyleN"/>6</rom-file>
-	<rom-file id="00020"><i18n-string id="Menu:StyleN"/>7</rom-file>
-	<rom-file id="00021"><i18n-string id="Menu:StyleN"/>8</rom-file>
-      </category>
-    </category>
-  </category>
-  <category><name><i18n-string id="Menu:ItemData"/></name>
-    <category><name><i18n-string id="Menu:English"/></name>
-      <rom-file id="00076"><i18n-string id="Menu:Armor"/></rom-file>
-      <rom-file id="55668"><i18n-string id="Menu:Armor"/> 2</rom-file>
-      <rom-file id="00091"><i18n-string id="Menu:Currency"/></rom-file>
-      <rom-file id="00073"><i18n-string id="Menu:GeneralItems"/></rom-file>
-      <rom-file id="55671"><i18n-string id="Menu:GeneralItems"/> 2</rom-file>
-      <rom-file id="00077"><i18n-string id="Menu:PuppetItems"/></rom-file>
-      <rom-file id="00074"><i18n-string id="Menu:UsableItems"/></rom-file>
-      <rom-file id="00075"><i18n-string id="Menu:Weapons"/></rom-file>
-      <rom-file id="55667"><i18n-string id="Menu:VouchersAndSlips"/></rom-file>
-      <rom-file id="55669"><i18n-string id="Menu:Monipulator"/></rom-file>
-      <rom-file id="55670"><i18n-string id="Menu:Instincts"/></rom-file>       
-    </category>
-    <category><name><i18n-string id="Menu:French"/></name>
-      <rom-file id="56238"><i18n-string id="Menu:Armor"/></rom-file>
-      <rom-file id="56208"><i18n-string id="Menu:Armor"/> 2</rom-file>
-      <rom-file id="56240"><i18n-string id="Menu:Currency"/></rom-file>
-      <rom-file id="56235"><i18n-string id="Menu:GeneralItems"/></rom-file>
-      <rom-file id="56211"><i18n-string id="Menu:GeneralItems"/> 2</rom-file>
-      <rom-file id="56239"><i18n-string id="Menu:PuppetItems"/></rom-file>
-      <rom-file id="56236"><i18n-string id="Menu:UsableItems"/></rom-file>
-      <rom-file id="56237"><i18n-string id="Menu:Weapons"/></rom-file>
-      <rom-file id="56207"><i18n-string id="Menu:VouchersAndSlips"/></rom-file>
-    </category>
-    <category><name><i18n-string id="Menu:German"/></name>
-      <rom-file id="55818"><i18n-string id="Menu:Armor"/></rom-file>
-      <rom-file id="55788"><i18n-string id="Menu:Armor"/> 2</rom-file>
-      <rom-file id="55820"><i18n-string id="Menu:Currency"/></rom-file>
-      <rom-file id="55815"><i18n-string id="Menu:GeneralItems"/></rom-file>
-      <rom-file id="55791"><i18n-string id="Menu:GeneralItems"/> 2</rom-file>
-      <rom-file id="55819"><i18n-string id="Menu:PuppetItems"/></rom-file>
-      <rom-file id="55816"><i18n-string id="Menu:UsableItems"/></rom-file>
-      <rom-file id="55817"><i18n-string id="Menu:Weapons"/></rom-file>
-      <rom-file id="56787"><i18n-string id="Menu:VouchersAndSlips"/></rom-file>
-    </category>
-    <category><name><i18n-string id="Menu:Japanese"/></name>
-      <rom-file id="00007"><i18n-string id="Menu:Armor"/></rom-file>
-      <rom-file id="55548"><i18n-string id="Menu:Armor"/> 2</rom-file>
-      <rom-file id="00009"><i18n-string id="Menu:Currency"/></rom-file>
-      <rom-file id="00004"><i18n-string id="Menu:GeneralItems"/></rom-file>
-      <rom-file id="55551"><i18n-string id="Menu:GeneralItems"/> 2</rom-file>
-      <rom-file id="00008"><i18n-string id="Menu:PuppetItems"/></rom-file>
-      <rom-file id="00005"><i18n-string id="Menu:UsableItems"/></rom-file>
-      <rom-file id="00006"><i18n-string id="Menu:Weapons"/></rom-file>
-      <rom-file id="55547"><i18n-string id="Menu:VouchersAndSlips"/></rom-file>
-    </category>
-  </category>
-  <category><name><i18n-string id="Menu:MobLists"/></name>
-    <!-- Language Independent: 06720-06975 -->
-    <category><name>&amp;<i18n-string id="FFXI1"/></name>
-      <category><name><region-name id="000"/></name>
-	<rom-file id="06953"><area-name id="233"/></rom-file>
-	<rom-file id="06951"><area-name id="231"/></rom-file>
-	<rom-file id="06952"><area-name id="232"/></rom-file>
-	<rom-file id="06950"><area-name id="230"/></rom-file>
-      </category>
-      <category><name><region-name id="001"/></name>
-	<rom-file id="06955"><area-name id="235"/></rom-file>
-	<rom-file id="06954"><area-name id="234"/></rom-file>
-	<rom-file id="06957"><area-name id="237"/></rom-file>
-	<rom-file id="06956"><area-name id="236"/></rom-file>
-      </category>
-      <category><name><region-name id="002"/></name>
-	<rom-file id="06962"><area-name id="242"/></rom-file>
-	<rom-file id="06960"><area-name id="240"/></rom-file>
-	<rom-file id="06959"><area-name id="239"/></rom-file>
-	<rom-file id="06958"><area-name id="238"/></rom-file>
-	<rom-file id="06961"><area-name id="241"/></rom-file>
-      </category>
-      <category><name><region-name id="003"/></name>
-	<rom-file id="06965"><area-name id="245"/></rom-file>
-	<rom-file id="06966"><area-name id="246"/></rom-file>
-	<rom-file id="06963"><area-name id="243"/></rom-file>
-	<rom-file id="06964"><area-name id="244"/></rom-file>
-      </category>
-      <category><name><region-name id="004"/></name>
-	<rom-file id="06887"><area-name id="167"/></rom-file>
-	<rom-file id="06821"><area-name id="101"/></rom-file>
-	<rom-file id="06861"><area-name id="141"/></rom-file>
-	<rom-file id="06860"><area-name id="140"/></rom-file>
-	<rom-file id="06859"><area-name id="139"/></rom-file>
-	<rom-file id="06910"><area-name id="190"/></rom-file>
-	<rom-file id="06820"><area-name id="100"/></rom-file>
-	<rom-file id="06862"><area-name id="142"/></rom-file>
-      </category>
-      <category><name><region-name id="005"/></name>
-	<rom-file id="06916"><area-name id="196"/></rom-file>
-	<rom-file id="06828"><area-name id="108"/></rom-file>
-	<rom-file id="06822"><area-name id="102"/></rom-file>
-	<rom-file id="06913"><area-name id="193"/></rom-file>
-	<rom-file id="06968"><area-name id="248"/></rom-file>
-	<rom-file id="06823"><area-name id="103"/></rom-file>
-      </category>
-      <category><name><region-name id="006"/></name>
-	<rom-file id="06825"><area-name id="105"/></rom-file>
-	<rom-file id="06722"><area-name id="002"/></rom-file>
-	<rom-file id="06869"><area-name id="149"/></rom-file>
-	<rom-file id="06824"><area-name id="104"/></rom-file>
-	<rom-file id="06870"><area-name id="150"/></rom-file>
-	<rom-file id="06721"><area-name id="001"/></rom-file>
-	<rom-file id="06915"><area-name id="195"/></rom-file>
-      </category>
-      <category><name><region-name id="007"/></name>
-	<rom-file id="06911"><area-name id="191"/></rom-file>
-	<rom-file id="06893"><area-name id="173"/></rom-file>
-	<rom-file id="06826"><area-name id="106"/></rom-file>
-	<rom-file id="06863"><area-name id="143"/></rom-file>
-	<rom-file id="06827"><area-name id="107"/></rom-file>
-	<rom-file id="06864"><area-name id="144"/></rom-file>
-	<rom-file id="06892"><area-name id="172"/></rom-file>
-      </category>
-      <category><name><region-name id="008"/></name>
-	<rom-file id="06867"><area-name id="147"/></rom-file>
-	<rom-file id="06917"><area-name id="197"/></rom-file>
-	<rom-file id="06829"><area-name id="109"/></rom-file>
-	<rom-file id="06868"><area-name id="148"/></rom-file>
-	<rom-file id="06830"><area-name id="110"/></rom-file>
-      </category>
-      <category><name><region-name id="009"/></name>
-	<rom-file id="06866"><area-name id="146"/></rom-file>
-	<rom-file id="06836"><area-name id="116"/></rom-file>
-	<rom-file id="06890"><area-name id="170"/></rom-file>
-	<rom-file id="06865"><area-name id="145"/></rom-file>
-	<rom-file id="06912"><area-name id="192"/></rom-file>
-	<rom-file id="06914"><area-name id="194"/></rom-file>
-	<rom-file id="06889"><area-name id="169"/></rom-file>
-	<rom-file id="06835"><area-name id="115"/></rom-file>
-      </category>
-      <category><name><region-name id="010"/></name>
-	<rom-file id="06724"><area-name id="004"/></rom-file>
-	<rom-file id="06838"><area-name id="118"/></rom-file>
-	<rom-file id="06933"><area-name id="213"/></rom-file>
-	<rom-file id="06723"><area-name id="003"/></rom-file>
-	<rom-file id="06918"><area-name id="198"/></rom-file>
-	<rom-file id="06969"><area-name id="249"/></rom-file>
-	<rom-file id="06837"><area-name id="117"/></rom-file>
-      </category>
-      <category><name><region-name id="011"/></name>
-	<rom-file id="06872"><area-name id="152"/></rom-file>
-	<rom-file id="06727"><area-name id="007"/></rom-file>
-	<rom-file id="06728"><area-name id="008"/></rom-file>
-	<rom-file id="06871"><area-name id="151"/></rom-file>
-	<rom-file id="06920"><area-name id="200"/></rom-file>
-	<rom-file id="06839"><area-name id="119"/></rom-file>
-	<rom-file id="06840"><area-name id="120"/></rom-file>
-      </category>
-      <category><name><region-name id="012"/></name>
-	<rom-file id="06831"><area-name id="111"/></rom-file>
-	<rom-file id="06923"><area-name id="203"/></rom-file>
-	<rom-file id="06924"><area-name id="204"/></rom-file>
-	<rom-file id="06729"><area-name id="009"/></rom-file>
-	<rom-file id="06886"><area-name id="166"/></rom-file>
-	<rom-file id="06926"><area-name id="206"/></rom-file>
-	<rom-file id="06730"><area-name id="010"/></rom-file>
-      </category>
-      <category><name><region-name id="013"/></name>
-	<rom-file id="06726"><area-name id="006"/></rom-file>
-	<rom-file id="06881"><area-name id="161"/></rom-file>
-	<rom-file id="06882"><area-name id="162"/></rom-file>
-	<rom-file id="06885"><area-name id="165"/></rom-file>
-	<rom-file id="06725"><area-name id="005"/></rom-file>
-	<rom-file id="06832"><area-name id="112"/></rom-file>
-      </category>
-      <category><name><region-name id="014"/></name>
-	<rom-file id="06847"><area-name id="127"/></rom-file>
-	<rom-file id="06904"><area-name id="184"/></rom-file>
-	<rom-file id="06877"><area-name id="157"/></rom-file>
-	<rom-file id="06851"><area-name id="131"/></rom-file>
-	<rom-file id="06846"><area-name id="126"/></rom-file>
-	<rom-file id="06899"><area-name id="179"/></rom-file>
-	<rom-file id="06878"><area-name id="158"/></rom-file>
-      </category>
-    </category>
-    <category><name>&amp;<i18n-string id="FFXI2"/></name>
-      <category><name><region-name id="015"/></name>
-	<rom-file id="06922"><area-name id="202"/></rom-file>
-	<rom-file id="06874"><area-name id="154"/></rom-file>
-	<rom-file id="06971"><area-name id="251"/></rom-file>
-	<rom-file id="06842"><area-name id="122"/></rom-file>
-	<rom-file id="06873"><area-name id="153"/></rom-file>
-	<rom-file id="06841"><area-name id="121"/></rom-file>
-      </category>
-      <category><name><region-name id="016"/></name>
-	<rom-file id="06888"><area-name id="168"/></rom-file>
-	<rom-file id="06929"><area-name id="209"/></rom-file>
-	<rom-file id="06834"><area-name id="114"/></rom-file>
-	<rom-file id="06928"><area-name id="208"/></rom-file>
-	<rom-file id="06967"><area-name id="247"/></rom-file>
-	<rom-file id="06845"><area-name id="125"/></rom-file>
-      </category>
-      <category><name><region-name id="017"/></name>
-	<rom-file id="06833"><area-name id="113"/></rom-file>
-	<rom-file id="06921"><area-name id="201"/></rom-file>
-	<rom-file id="06932"><area-name id="212"/></rom-file>
-	<rom-file id="06894"><area-name id="174"/></rom-file>
-	<rom-file id="06848"><area-name id="128"/></rom-file>
-      </category>
-      <category><name><region-name id="018"/></name>
-	<rom-file id="06970"><area-name id="250"/></rom-file>
-	<rom-file id="06972"><area-name id="252"/></rom-file>
-	<rom-file id="06896"><area-name id="176"/></rom-file>
-	<rom-file id="06843"><area-name id="123"/></rom-file>
-      </category>
-      <category><name><region-name id="019"/></name>
-	<rom-file id="06927"><area-name id="207"/></rom-file>
-	<rom-file id="06931"><area-name id="211"/></rom-file>
-	<rom-file id="06880"><area-name id="160"/></rom-file>
-	<rom-file id="06925"><area-name id="205"/></rom-file>
-	<rom-file id="06883"><area-name id="163"/></rom-file>
-	<rom-file id="06879"><area-name id="159"/></rom-file>
-	<rom-file id="06844"><area-name id="124"/></rom-file>
-      </category>
-      <category><name><region-name id="020"/></name>
-	<rom-file id="06900"><area-name id="180"/></rom-file>
-	<rom-file id="06850"><area-name id="130"/></rom-file>
-	<rom-file id="06901"><area-name id="181"/></rom-file>
-	<rom-file id="06898"><area-name id="178"/></rom-file>
-	<rom-file id="06897"><area-name id="177"/></rom-file>
-      </category>
-      <category><name><region-name id="021"/></name>
-	<rom-file id="06906"><area-name id="186"/></rom-file>
-	<rom-file id="06854"><area-name id="134"/></rom-file>
-	<rom-file id="06760"><area-name id="040"/></rom-file>
-	<rom-file id="06908"><area-name id="188"/></rom-file>
-	<rom-file id="06761"><area-name id="041"/></rom-file>
-	<rom-file id="06905"><area-name id="185"/></rom-file>
-	<rom-file id="06762"><area-name id="042"/></rom-file>
-	<rom-file id="06759"><area-name id="039"/></rom-file>
-	<rom-file id="06907"><area-name id="187"/></rom-file>
-	<rom-file id="06855"><area-name id="135"/></rom-file>
-      </category>
-    </category>
-    <category><name>&amp;<i18n-string id="FFXI3"/></name>
-      <category><name><region-name id="022"/></name>
-	<rom-file id="06732"><area-name id="012"/></rom-file>
-	<rom-file id="06733"><area-name id="013"/></rom-file>
-	<rom-file id="06731"><area-name id="011"/></rom-file>
-      </category>
-      <category><name><region-name id="023"/></name>
-	<rom-file id="06746"><area-name id="026"/></rom-file>
-      </category>
-      <category><name><region-name id="024"/></name>
-	<rom-file id="06744"><area-name id="024"/></rom-file>
-	<rom-file id="06745"><area-name id="025"/></rom-file>
-	<rom-file id="06747"><area-name id="027"/></rom-file>
-	<rom-file id="06748"><area-name id="028"/></rom-file>
-	<rom-file id="06749"><area-name id="029"/></rom-file>
-	<rom-file id="06750"><area-name id="030"/></rom-file>
-	<rom-file id="06751"><area-name id="031"/></rom-file>
-	<rom-file id="06752"><area-name id="032"/></rom-file>
-      </category>
-      <category><name><region-name id="025"/></name>
-	<rom-file id="06734"><area-name id="014"/></rom-file>
-	<rom-file id="06738"><area-name id="018"/></rom-file>
-	<rom-file id="06736"><area-name id="016"/></rom-file>
-	<rom-file id="06740"><area-name id="020"/></rom-file>
-	<rom-file id="06742"><area-name id="022"/></rom-file>
-	<rom-file id="06739"><area-name id="019"/></rom-file>
-	<rom-file id="06737"><area-name id="017"/></rom-file>
-	<rom-file id="06741"><area-name id="021"/></rom-file>
-	<rom-file id="06743"><area-name id="023"/></rom-file>
-      </category>
-      <category><name><region-name id="026"/></name>
-	<rom-file id="06753"><area-name id="033"/></rom-file>
-	<rom-file id="06756"><area-name id="036"/></rom-file>
-	<rom-file id="06754"><area-name id="034"/></rom-file>
-	<rom-file id="06755"><area-name id="035"/></rom-file>
-      </category>
-      <category><name><region-name id="027"/></name>
-	<rom-file id="06758"><area-name id="038"/></rom-file>
-	<rom-file id="06757"><area-name id="037"/></rom-file>
-      </category>
-    </category>
-    <category><name>&amp;<i18n-string id="FFXI4"/></name>
-      <category><name><region-name id="028"/></name></category>
-      <category><name><region-name id="029"/></name>
-	<rom-file id="06770"><area-name id="050"/></rom-file>
-	<rom-file id="06768"><area-name id="048"/></rom-file>
-	<rom-file id="06772"><area-name id="052"/></rom-file>
-	<rom-file id="06790"><area-name id="070"/></rom-file>
-	<rom-file id="06791"><area-name id="071"/></rom-file>
-      </category>
-      <category><name><region-name id="030"/></name>
-	<rom-file id="06788"><area-name id="068"/></rom-file>
-	<rom-file id="06787"><area-name id="067"/></rom-file>
-	<rom-file id="06785"><area-name id="065"/></rom-file>
-	<rom-file id="06786"><area-name id="066"/></rom-file>
-	<rom-file id="06771"><area-name id="051"/></rom-file>
-      </category>
-      <category><name><region-name id="031"/></name>
-	<rom-file id="06782"><area-name id="062"/></rom-file>
-	<rom-file id="06783"><area-name id="063"/></rom-file>
-	<rom-file id="06781"><area-name id="061"/></rom-file>
-	<rom-file id="06784"><area-name id="064"/></rom-file>
-      </category>
-      <category><name><region-name id="032"/></name>
-	<rom-file id="06774"><area-name id="054"/></rom-file>
-	<rom-file id="06799"><area-name id="079"/></rom-file>
-	<rom-file id="06775"><area-name id="055"/></rom-file>
-	<rom-file id="06789"><area-name id="069"/></rom-file>
-	<rom-file id="06773"><area-name id="053"/></rom-file>
-	<rom-file id="06797"><area-name id="077"/></rom-file>
-	<rom-file id="06776"><area-name id="056"/></rom-file>
-	<rom-file id="06777"><area-name id="057"/></rom-file>
-	<rom-file id="06780"><area-name id="060"/></rom-file>
-      </category>
-      <category><name><region-name id="033"/></name>
-	<rom-file id="06792"><area-name id="072"/></rom-file>
-	<rom-file id="06794"><area-name id="074"/></rom-file>
-	<rom-file id="06795"><area-name id="075"/></rom-file>
-	<rom-file id="06798"><area-name id="078"/></rom-file>
-	<rom-file id="06796"><area-name id="076"/></rom-file>
-	<rom-file id="06793"><area-name id="073"/></rom-file>
-      </category>
-    </category>
-    <category><name>&amp;<i18n-string id="FFXI5"/></name>
-      <category><name><region-name id="034"/></name>
-	<rom-file id="06801"><area-name id="081"/></rom-file>
-	<rom-file id="06806"><area-name id="086"/></rom-file>
-	<rom-file id="06800"><area-name id="080"/></rom-file>
-      </category>
-      <category><name><region-name id="035"/></name>
-	<rom-file id="06804"><area-name id="084"/></rom-file>
-	<rom-file id="06802"><area-name id="082"/></rom-file>
-	<rom-file id="06805"><area-name id="085"/></rom-file>
-	<rom-file id="06895"><area-name id="175"/></rom-file>
-      </category>
-      <category><name><region-name id="036"/></name>
-	<rom-file id="06807"><area-name id="087"/></rom-file>
-	<rom-file id="06809"><area-name id="089"/></rom-file>
-	<rom-file id="06808"><area-name id="088"/></rom-file>
-	<rom-file id="06813"><area-name id="093"/></rom-file>
-      </category>
-      <category><name><region-name id="037"/></name>
-	<rom-file id="06812"><area-name id="092"/></rom-file>
-	<rom-file id="06891"><area-name id="171"/></rom-file>
-	<rom-file id="06810"><area-name id="090"/></rom-file>
-	<rom-file id="06811"><area-name id="091"/></rom-file>
-	<rom-file id="06803"><area-name id="083"/></rom-file>
-      </category>
-      <category><name><region-name id="038"/></name>
-	<rom-file id="06816"><area-name id="096"/></rom-file>
-	<rom-file id="06849"><area-name id="129"/></rom-file>
-	<rom-file id="06815"><area-name id="095"/></rom-file>
-	<rom-file id="06814"><area-name id="094"/></rom-file>
-      </category>
-      <category><name><region-name id="039"/></name>
-	<rom-file id="06819"><area-name id="099"/></rom-file>
-	<rom-file id="06884"><area-name id="164"/></rom-file>
-	<rom-file id="06817"><area-name id="097"/></rom-file>
-	<rom-file id="06818"><area-name id="098"/></rom-file>
-      </category>
-      <category><name><region-name id="040"/></name>
-	<rom-file id="06856"><area-name id="136"/></rom-file>
-      </category>
-      <category><name><region-name id="041"/></name>
-	<rom-file id="06858"><area-name id="138"/></rom-file>
-	<rom-file id="06875"><area-name id="155"/></rom-file>
-	<rom-file id="06876"><area-name id="156"/></rom-file>
-	<rom-file id="06857"><area-name id="137"/></rom-file>
-      </category>
-      <category><name><region-name id="042"/></name>
-      </category>
-      <category><name><region-name id="043"/></name>
-      </category>
-      <category><name><region-name id="044"/></name>
-      </category>
-      <category><name><region-name id="045"/></name>
-      </category>
-    <category><name><region-name id="047"/></name>
-        <rom-file id="06902"><area-name id="182"/></rom-file>
-        <rom-file id="06942"><area-name id="222"/></rom-file>
-    </category>
-    </category>
-    <category><name><i18n-string id="Menu:Abyssea"/></name>
-      <rom-file id="06935"><area-name id="215"/></rom-file>
-      <rom-file id="06735"><area-name id="015"/></rom-file>
-      <rom-file id="06852"><area-name id="132"/></rom-file>
-      <rom-file id="06936"><area-name id="216"/></rom-file>
-      <rom-file id="06765"><area-name id="045"/></rom-file>
-      <rom-file id="06937"><area-name id="217"/></rom-file>
-      <rom-file id="06938"><area-name id="218"/></rom-file>
-      <rom-file id="06973"><area-name id="253"/></rom-file>
-      <rom-file id="06974"><area-name id="254"/></rom-file>
-      <rom-file id="06975"><area-name id="255"/></rom-file>
-    </category>
-    <category><name>&amp;<i18n-string id="FFXI9"/></name>
-     <category><name><region-name id="049"/></name>
-      <rom-file id="86491"><area-name id="256"/></rom-file>
-      <rom-file id="86492"><area-name id="257"/></rom-file>
-      <rom-file id="86493"><area-name id="258"/></rom-file>
-      <rom-file id="86494"><area-name id="259"/></rom-file>
-     </category> 
-     <category><name><region-name id="050"/></name>
-      <rom-file id="86495"><area-name id="260"/></rom-file>
-      <rom-file id="86496"><area-name id="261"/></rom-file>
-      <rom-file id="86497"><area-name id="262"/></rom-file>
-      <rom-file id="86498"><area-name id="263"/></rom-file>
-      <rom-file id="86499"><area-name id="264"/></rom-file>
-      <rom-file id="86500"><area-name id="265"/></rom-file>
-      <rom-file id="86501"><area-name id="266"/></rom-file>
-      <rom-file id="86502"><area-name id="267"/></rom-file>
-      <rom-file id="86503"><area-name id="268"/></rom-file>
-      <rom-file id="86504"><area-name id="269"/></rom-file>
-      <rom-file id="86505"><area-name id="270"/></rom-file>
-      <rom-file id="86506"><area-name id="271"/></rom-file>
-      <rom-file id="86507"><area-name id="272"/></rom-file>
-      <rom-file id="86508"><area-name id="273"/></rom-file>
-      <rom-file id="86509"><area-name id="274"/></rom-file>
-      <rom-file id="86510"><area-name id="275"/></rom-file>
-      <rom-file id="86511"><area-name id="276"/></rom-file>
-      <rom-file id="86512"><area-name id="277"/></rom-file>
-      <rom-file id="86519"><area-name id="284"/></rom-file>
-      <rom-file id="86515"><area-name id="280"/></rom-file>
-     </category>
-    </category>
-    <category><name><i18n-string id="Menu:Other"/></name>
-      <category><name><i18n-string id="Menu:MoblinMaze"/></name>
-        <rom-file id="67911"><i18n-string id="Menu:SanitizationAlpha"/></rom-file>
-        <rom-file id="67912"><i18n-string id="Menu:SanitizationBeta"/></rom-file>
-        <rom-file id="67913"><i18n-string id="Menu:SanitizationGamma"/></rom-file>
-        <rom-file id="67914"><i18n-string id="Menu:Materialization"/></rom-file>
-        <rom-file id="67915"><i18n-string id="Menu:Actualization"/></rom-file>
-        <rom-file id="67916"><i18n-string id="Menu:Appropriation"/></rom-file>
-        <rom-file id="67917"><i18n-string id="Menu:Liquidation"/></rom-file>
-        <rom-file id="67918"><i18n-string id="Menu:AquaticDepopulation"/></rom-file>
-        <rom-file id="67919"><i18n-string id="Menu:Revitalization"/></rom-file>
-      </category>
-      <category><name><i18n-string id="Menu:MeebleBurrows"/></name>
-        <rom-file id="67920"><i18n-string id="Menu:Adjunct"/></rom-file>
-        <rom-file id="67921"><i18n-string id="Menu:Assistant"/></rom-file>
-        <rom-file id="67922"><i18n-string id="Menu:Instructor"/></rom-file>
-        <rom-file id="67923"><i18n-string id="Menu:AssociateResearcher"/></rom-file>
-        <rom-file id="67924"><i18n-string id="Menu:Researcher"/></rom-file>
-        <rom-file id="67925"><i18n-string id="Menu:BAdjunct"/></rom-file>
-        <rom-file id="67926"><i18n-string id="Menu:BAssistant"/></rom-file>
-        <rom-file id="67927"><i18n-string id="Menu:BInstructor"/></rom-file>
-      </category>
-      <separator/>
-      <rom-file id="06944"><area-name id="224"/></rom-file>
-      <rom-file id="06946"><area-name id="226"/></rom-file>
-      <rom-file id="06943"><area-name id="223"/></rom-file>
-      <rom-file id="06945"><area-name id="225"/></rom-file>
-      <separator/>
-      <rom-file id="06941"><area-name id="221"/></rom-file>
-      <rom-file id="06948"><area-name id="228"/> <i18n-string id="Menu:WithPirates"/></rom-file>
-      <rom-file id="06940"><area-name id="220"/></rom-file>
-      <rom-file id="06947"><area-name id="227"/> <i18n-string id="Menu:WithPirates"/></rom-file>
-      <separator/>
-      <rom-file id="06766"><area-name id="046"/></rom-file>
-      <rom-file id="06767"><area-name id="047"/></rom-file>
-      <rom-file id="06778"><area-name id="058"/></rom-file>
-      <rom-file id="06779"><area-name id="059"/></rom-file>
-      <separator/>
-      <rom-file id="06763"><area-name id="043"/></rom-file>
-      <rom-file id="06764"><area-name id="044"/></rom-file>
-      <rom-file id="06903"><area-name id="183"/></rom-file>
-      <separator/>
-      <rom-file id="86520"><area-name id="285"/></rom-file>
-      <separator/>
-      <!-- NOTE: <area-name id="210"/> won't do because in the client this is blank,
-           but leaked official documentation names it "GM Home" -->
-      <rom-file id="06930">GM Home</rom-file>
-    </category>
-  </category>
-  <category><name><i18n-string id="Menu:StringTables"/></name>
-    <category><name><i18n-string id="Menu:English"/></name>
-      <rom-file id="55701"><i18n-string id="Menu:AbilityNames"/></rom-file>
-      <rom-file id="55733"><i18n-string id="Menu:AbilityDescriptions"/></rom-file>
-      <rom-file id="55465"><i18n-string id="Menu:AreaNames"/></rom-file>
-      <rom-file id="55661"><i18n-string id="Menu:AreaNamesAlt"/></rom-file>
-      <rom-file id="55470"><i18n-string id="Menu:CharacterSelect"/></rom-file>
-      <rom-file id="55650"><i18n-string id="Menu:ChatFilterTypes"/></rom-file>
-      <rom-file id="55658"><i18n-string id="Menu:DayNames"/></rom-file>
-      <rom-file id="55659"><i18n-string id="Menu:Directions"/></rom-file>
-      <rom-file id="55471"><i18n-string id="Menu:EquipmentLocations"/></rom-file>
-      <rom-file id="55646"><i18n-string id="Menu:ErrorMessages"/></rom-file>
-      <rom-file id="55648"><i18n-string id="Menu:InGameMessages1"/></rom-file>
-      <rom-file id="55649"><i18n-string id="Menu:InGameMessages2"/></rom-file>
-      <rom-file id="55467"><i18n-string id="Menu:JobNames"/></rom-file>
-      <rom-file id="55695"><i18n-string id="Menu:KeyItems"/></rom-file><!-- alternative file IDs: 55696,55697,55698,55699,55700,55703,55705,55713,55714 -->
-      <rom-file id="55651"><i18n-string id="Menu:MenuItemDesc"/></rom-file>
-      <rom-file id="55652"><i18n-string id="Menu:MenuItemText"/></rom-file>
-      <category><name><i18n-string id="Menu:Missions"/></name>
-	<rom-file id="55715">San d'Oria</rom-file>
-	<rom-file id="55716">Bastok</rom-file>
-	<rom-file id="55717">Windurst</rom-file>
-	<rom-file id="55718">Zilart</rom-file>
-	<rom-file id="55719">Promathia</rom-file>
-	<rom-file id="55720">Assault</rom-file>
-	<rom-file id="55721">Aht Urhgan</rom-file>
-	<rom-file id="55723">Goddess</rom-file>
-	<rom-file id="55724">Campaign</rom-file>
-	<rom-file id="55738">Adoulin</rom-file>
-	<rom-file id="55740">Coalition</rom-file>
-	<rom-file id="55735">A Crystalline Prophecy</rom-file>
-	<rom-file id="55736">A Moogle Kupo d'Etat</rom-file>
-	<rom-file id="55737">A Shantotto Ascension</rom-file>
-      </category>
-      <rom-file id="55660"><i18n-string id="Menu:MoonPhases"/></rom-file>
-      <rom-file id="55647"><i18n-string id="Menu:POLMessages"/></rom-file>
-      <category><name><i18n-string id="Menu:Quests"/></name>
-	<rom-file id="55706">San d'Oria</rom-file>
-	<rom-file id="55707">Bastok</rom-file>
-	<rom-file id="55708">Windurst</rom-file>
-	<rom-file id="55709">Jeuno</rom-file>
-	<rom-file id="55710">Other</rom-file>
-	<rom-file id="55711">Zilart</rom-file>
-	<rom-file id="55712">Aht Urhgan</rom-file>
-	<rom-file id="55722">Goddess</rom-file>
-	<rom-file id="55739">Adoulin</rom-file>
-	<rom-file id="55713">Abyssea</rom-file>
-      </category>
-      <rom-file id="55469"><i18n-string id="Menu:RaceNames"/></rom-file>
-      <rom-file id="55654"><i18n-string id="Menu:RegionNames"/></rom-file>
-      <rom-file id="55702"><i18n-string id="Menu:SpellNames"/></rom-file>
-      <rom-file id="55734"><i18n-string id="Menu:SpellDescriptions"/></rom-file>
-      <rom-file id="00087"><i18n-string id="Menu:StatusInfo"/></rom-file>
-      <rom-file id="55725"><i18n-string id="Menu:StatusNames"/></rom-file><!-- alternative file IDs: 55726,55727,55728,55729,55730,55731,55732 -->
-      <rom-file id="00063"><i18n-string id="Menu:TimeAndPronouns"/></rom-file>
-      <rom-file id="55704"><i18n-string id="Menu:Titles"/></rom-file>
-      <rom-file id="55645"><i18n-string id="Menu:Various1"/></rom-file>
-      <rom-file id="55653"><i18n-string id="Menu:Various2"/></rom-file>
-      <rom-file id="55657"><i18n-string id="Menu:WeatherTypes"/></rom-file>
-    </category>
-    <category><name><i18n-string id="Menu:French"/></name>
-      <rom-file id="56241"><i18n-string id="Menu:AbilityNames"/></rom-file>
-      <rom-file id="56273"><i18n-string id="Menu:AbilityDescriptions"/></rom-file>
-      <rom-file id="56195"><i18n-string id="Menu:AreaNames"/></rom-file>
-      <rom-file id="56225"><i18n-string id="Menu:BlueMagicHelp"/></rom-file>
-      <rom-file id="56202"><i18n-string id="Menu:CharacterSelect"/></rom-file>
-      <rom-file id="56190"><i18n-string id="Menu:ChatFilterTypes"/></rom-file>
-      <rom-file id="56198"><i18n-string id="Menu:DayNames"/></rom-file>
-      <rom-file id="56199"><i18n-string id="Menu:Directions"/></rom-file>
-      <rom-file id="56206"><i18n-string id="Menu:EquipmentLocations"/></rom-file>
-      <rom-file id="56186"><i18n-string id="Menu:ErrorMessages"/></rom-file>
-      <rom-file id="56188"><i18n-string id="Menu:InGameMessages1"/></rom-file>
-      <rom-file id="56189"><i18n-string id="Menu:InGameMessages2"/></rom-file>
-      <rom-file id="56196"><i18n-string id="Menu:JobNames"/></rom-file>
-      <rom-file id="56245"><i18n-string id="Menu:KeyItems"/></rom-file><!-- alternative file IDs: 56253,56254 -->
-      <rom-file id="56191"><i18n-string id="Menu:MenuItemDesc"/></rom-file>
-      <rom-file id="56192"><i18n-string id="Menu:MenuItemText"/></rom-file>
-      <rom-file id="56226"><i18n-string id="Menu:MeripoHelp"/></rom-file>
-      <category><name><i18n-string id="Menu:Missions"/></name>
-	<rom-file id="56255">San d'Oria</rom-file>
-	<rom-file id="56256">Bastok</rom-file>
-	<rom-file id="56257">Windurst</rom-file>
-	<rom-file id="56258">Zilart</rom-file>
-	<rom-file id="56259">Promathia</rom-file>
-	<rom-file id="56260">Assault</rom-file>
-	<rom-file id="56261">Aht Urhgan</rom-file>
-	<rom-file id="56263">Goddess</rom-file>
-	<rom-file id="56264">Campaign</rom-file>
-	<rom-file id="56275">A Crystalline Prophecy</rom-file>
-	<rom-file id="56276">A Moogle Kupo d'Etat</rom-file>
-	<rom-file id="56277">A Shantotto Ascension</rom-file>
-      </category>
-      <rom-file id="56200"><i18n-string id="Menu:MoonPhases"/></rom-file>
-      <rom-file id="56187"><i18n-string id="Menu:POLMessages"/></rom-file>
-      <category><name><i18n-string id="Menu:Quests"/></name>
-	<rom-file id="56246">San d'Oria</rom-file>
-	<rom-file id="56247">Bastok</rom-file>
-	<rom-file id="56248">Windurst</rom-file>
-	<rom-file id="56249">Jeuno</rom-file>
-	<rom-file id="56250">Other</rom-file>
-	<rom-file id="56251">Zilart</rom-file>
-	<rom-file id="56252">Aht Urhgan</rom-file>
-	<rom-file id="56262">Goddess</rom-file>
-	<rom-file id="56253">Abyssea</rom-file>
-      </category>
-      <rom-file id="56203"><i18n-string id="Menu:RaceNames"/></rom-file>
-      <rom-file id="56194"><i18n-string id="Menu:RegionNames"/></rom-file>
-      <rom-file id="56242"><i18n-string id="Menu:SpellNames"/></rom-file>
-      <rom-file id="56274"><i18n-string id="Menu:SpellDescriptions"/></rom-file>
-      <rom-file id="56243"><i18n-string id="Menu:StatusInfo"/></rom-file>
-      <rom-file id="56272"><i18n-string id="Menu:StatusNames"/></rom-file>
-      <!--<rom-file id="00045"><i18n-string id="Menu:TimeAndPronouns"/></rom-file>-->
-      <rom-file id="56244"><i18n-string id="Menu:Titles"/></rom-file>
-      <rom-file id="56185"><i18n-string id="Menu:Various1"/></rom-file>
-      <rom-file id="56193"><i18n-string id="Menu:Various2"/></rom-file>
-      <rom-file id="56197"><i18n-string id="Menu:WeatherTypes"/></rom-file>
-    </category>
-    <category><name><i18n-string id="Menu:German"/></name>
-      <rom-file id="55821"><i18n-string id="Menu:AbilityNames"/></rom-file>
-      <rom-file id="55853"><i18n-string id="Menu:AbilityDescriptions"/></rom-file>  
-      <rom-file id="55775"><i18n-string id="Menu:AreaNames"/></rom-file><!-- also: 55781 -->
-      <rom-file id="55805"><i18n-string id="Menu:BlueMagicHelp"/></rom-file>
-      <rom-file id="55782"><i18n-string id="Menu:CharacterSelect"/></rom-file>
-      <rom-file id="55770"><i18n-string id="Menu:ChatFilterTypes"/></rom-file>
-      <rom-file id="55778"><i18n-string id="Menu:DayNames"/></rom-file>
-      <rom-file id="55779"><i18n-string id="Menu:Directions"/></rom-file>
-      <rom-file id="55786"><i18n-string id="Menu:EquipmentLocations"/></rom-file>
-      <rom-file id="55766"><i18n-string id="Menu:ErrorMessages"/></rom-file>
-      <rom-file id="55768"><i18n-string id="Menu:InGameMessages1"/></rom-file>
-      <rom-file id="55769"><i18n-string id="Menu:InGameMessages2"/></rom-file>
-      <rom-file id="55776"><i18n-string id="Menu:JobNames"/></rom-file>
-      <rom-file id="55825"><i18n-string id="Menu:KeyItems"/></rom-file>
-      <rom-file id="55806"><i18n-string id="Menu:MeripoHelp"/></rom-file>
-      <rom-file id="55771"><i18n-string id="Menu:MenuItemDesc"/></rom-file>
-      <rom-file id="55772"><i18n-string id="Menu:MenuItemText"/></rom-file>
-      <category><name><i18n-string id="Menu:Missions"/></name>
-	<rom-file id="55835">San d'Oria</rom-file>
-	<rom-file id="55836">Bastok</rom-file>
-	<rom-file id="55837">Windurst</rom-file>
-	<rom-file id="55838">Zilart</rom-file>
-	<rom-file id="55839">Promathia</rom-file>
-	<rom-file id="55840">Assault</rom-file>
-	<rom-file id="55841">Aht Urhgan</rom-file>
-	<rom-file id="55843">Goddess</rom-file>
-	<rom-file id="55844">Campaign</rom-file>
-	<rom-file id="55855">A Crystalline Prophecy</rom-file>
-	<rom-file id="55856">A Moogle Kupo d'Etat</rom-file>
-	<rom-file id="55857">A Shantotto Ascension</rom-file>
-      </category>
-      <rom-file id="55780"><i18n-string id="Menu:MoonPhases"/></rom-file>
-      <rom-file id="55767"><i18n-string id="Menu:POLMessages"/></rom-file>
-      <category><name><i18n-string id="Menu:Quests"/></name>
-	<rom-file id="55826">San d'Oria</rom-file>
-	<rom-file id="55827">Bastok</rom-file>
-	<rom-file id="55828">Windurst</rom-file>
-	<rom-file id="55829">Jeuno</rom-file>
-	<rom-file id="55830">Other</rom-file>
-	<rom-file id="55831">Zilart</rom-file>
-	<rom-file id="55832">Aht Urhgan</rom-file>
-	<rom-file id="55842">Goddess</rom-file>
-	<rom-file id="55833">Abyssea</rom-file>
-      </category>
-      <rom-file id="55783"><i18n-string id="Menu:RaceNames"/></rom-file>
-      <rom-file id="55774"><i18n-string id="Menu:RegionNames"/></rom-file>
-      <rom-file id="55822"><i18n-string id="Menu:SpellNames"/></rom-file>
-      <rom-file id="55854"><i18n-string id="Menu:SpellDescriptions"/></rom-file>
-      <rom-file id="55823"><i18n-string id="Menu:StatusInfo"/></rom-file>
-      <rom-file id="55852"><i18n-string id="Menu:StatusNames"/></rom-file>
-      <!--<rom-file id="00045"><i18n-string id="Menu:TimeAndPronouns"/></rom-file>-->
-      <rom-file id="55824"><i18n-string id="Menu:Titles"/></rom-file>
-      <rom-file id="55765"><i18n-string id="Menu:Various1"/></rom-file>
-      <rom-file id="55773"><i18n-string id="Menu:Various2"/></rom-file>
-      <rom-file id="55777"><i18n-string id="Menu:WeatherTypes"/></rom-file>
-    </category>
-    <category><name><i18n-string id="Menu:Japanese"/></name>
-      <rom-file id="55581"><i18n-string id="Menu:AbilityNames"/></rom-file>
-      <rom-file id="55613"><i18n-string id="Menu:AbilityDescriptions"/></rom-file>
-      <rom-file id="55535"><i18n-string id="Menu:AreaNames"/></rom-file>
-      <rom-file id="55530"><i18n-string id="Menu:ChatFilterTypes"/></rom-file>
-      <rom-file id="55538"><i18n-string id="Menu:DayNames"/></rom-file>
-      <rom-file id="55539"><i18n-string id="Menu:Directions"/></rom-file>
-      <rom-file id="55526"><i18n-string id="Menu:ErrorMessages"/></rom-file>
-      <rom-file id="55528"><i18n-string id="Menu:InGameMessages1"/></rom-file>
-      <rom-file id="55529"><i18n-string id="Menu:InGameMessages2"/></rom-file>
-      <rom-file id="55536"><i18n-string id="Menu:JobNames"/></rom-file>
-      <rom-file id="55575"><i18n-string id="Menu:KeyItems"/></rom-file><!-- alternative file IDs: 55576,55577,55578,55579,55580,55583,55585,55593,55594 -->
-      <rom-file id="55531"><i18n-string id="Menu:MenuItemDesc"/></rom-file>
-      <rom-file id="55532"><i18n-string id="Menu:MenuItemText"/></rom-file>
-      <category><name><i18n-string id="Menu:Missions"/></name>
-	<rom-file id="55595">San d'Oria</rom-file>
-	<rom-file id="55596">Bastok</rom-file>
-	<rom-file id="55597">Windurst</rom-file>
-	<rom-file id="55598">Zilart</rom-file>
-	<rom-file id="55599">Promathia</rom-file>
-	<rom-file id="55600">Assault</rom-file>
-	<rom-file id="55601">Aht Urhgan</rom-file>
-	<rom-file id="55603">Goddess</rom-file>
-	<rom-file id="55604">Campaign</rom-file>
-	<rom-file id="55615">A Crystalline Prophecy</rom-file>
-	<rom-file id="55616">A Moogle Kupo d'Etat</rom-file>
-	<rom-file id="55617">A Shantotto Ascension</rom-file>
-      </category>
-      <rom-file id="55540"><i18n-string id="Menu:MoonPhases"/></rom-file>
-      <rom-file id="55527"><i18n-string id="Menu:POLMessages"/></rom-file>
-      <category><name><i18n-string id="Menu:Quests"/></name>
-	<rom-file id="55586">San d'Oria</rom-file>
-	<rom-file id="55587">Bastok</rom-file>
-	<rom-file id="55588">Windurst</rom-file>
-	<rom-file id="55589">Jeuno</rom-file>
-	<rom-file id="55590">Other</rom-file>
-	<rom-file id="55591">Zilart</rom-file>
-	<rom-file id="55592">Aht Urhgan</rom-file>
-	<rom-file id="55602">Goddess</rom-file>
-	<rom-file id="55593">Abyssea</rom-file>
-      </category>
-      <rom-file id="55534"><i18n-string id="Menu:RegionNames"/></rom-file>
-      <rom-file id="55582"><i18n-string id="Menu:SpellNames"/></rom-file>
-      <rom-file id="55614"><i18n-string id="Menu:SpellDescriptions"/></rom-file>
-      <rom-file id="00012"><i18n-string id="Menu:StatusInfo"/></rom-file>
-      <rom-file id="55605"><i18n-string id="Menu:StatusNames"/></rom-file><!-- alternative file IDs: 55606,55607,55608,55609,55610,55611,55612 -->
-      <rom-file id="00045"><i18n-string id="Menu:TimeAndPronouns"/></rom-file>
-      <rom-file id="55584"><i18n-string id="Menu:Titles"/></rom-file>
-      <rom-file id="55525"><i18n-string id="Menu:Various1"/></rom-file>
-      <rom-file id="55533"><i18n-string id="Menu:Various2"/></rom-file>
-      <rom-file id="55537"><i18n-string id="Menu:WeatherTypes"/></rom-file>
-    </category>
-    <category><name><i18n-string id="Menu:Common"/></name>
-      <rom-file id="55466"><i18n-string id="Menu:AreaNamesShort"/></rom-file>
-      <rom-file id="55468"><i18n-string id="Menu:JobNamesShort"/></rom-file>
-      <rom-file id="00081"><i18n-string id="Menu:Spells"/> &amp;&amp; <i18n-string id="Menu:Abilities"/></rom-file>
-      <rom-file id="00011"><i18n-string id="Menu:Spells"/> (Old, Stale)</rom-file>
-      <rom-file id="00086"><i18n-string id="Menu:Spells"/> (Even Older)</rom-file>
-    </category>
-  </category>
 </rom-file-mappings>

--- a/PlayOnline.FFXI.Utils.DataBrowser/ROMFileMappings.xml
+++ b/PlayOnline.FFXI.Utils.DataBrowser/ROMFileMappings.xml
@@ -1488,6 +1488,11 @@
                 <rom-file id="06174"><area-name id="254"/></rom-file>
                 <rom-file id="06375"><area-name id="255"/></rom-file>
             </category>
+            <category><name><i18n-string id="Rhapsodies of Vana'diel"/></name>
+            <!-- NOTE: For some reason "Menu:" kept showing up in the menu..Even though existing entries were formatted that way.. -->
+                <rom-file id="85323"><area-name id="288"/></rom-file>
+                <rom-file id="85324"><area-name id="289"/></rom-file>
+            </category>
             <category><name><i18n-string id="Menu:Other"/></name>
                 <rom-file id="06344"><area-name id="224"/></rom-file>
                 <rom-file id="06346"><area-name id="226"/></rom-file>
@@ -1507,6 +1512,9 @@
                 <rom-file id="06163"><area-name id="043"/></rom-file>
                 <rom-file id="06164"><area-name id="044"/></rom-file>
                 <rom-file id="06303"><area-name id="183"/></rom-file>
+                <separator/>
+                <!-- NOTE: <area-name id="210"/> won't do because in the client this is blank, but leaked official documentation names it "GM Home" -->
+                <rom-file id="06330">GM Home</rom-file>
                 <separator/>
                 <rom-file id="07034"><i18n-string id="Menu:MonsterSkillNames"/></rom-file>
             </category>
@@ -2925,6 +2933,7 @@
                 <rom-file id="55735">A Crystalline Prophecy</rom-file>
                 <rom-file id="55736">A Moogle Kupo d'Etat</rom-file>
                 <rom-file id="55737">A Shantotto Ascension</rom-file>
+                <rom-file id="56281">Rhapsodies of Vana'diel</rom-file>
             </category>
             <rom-file id="55660"><i18n-string id="Menu:MoonPhases"/></rom-file>
             <rom-file id="55647"><i18n-string id="Menu:POLMessages"/></rom-file>
@@ -3093,6 +3102,7 @@
                 <rom-file id="55615">A Crystalline Prophecy</rom-file>
                 <rom-file id="55616">A Moogle Kupo d'Etat</rom-file>
                 <rom-file id="55617">A Shantotto Ascension</rom-file>
+                <rom-file id="55621">Rhapsodies of Vana'diel</rom-file>
             </category>
             <rom-file id="55540"><i18n-string id="Menu:MoonPhases"/></rom-file>
             <rom-file id="55527"><i18n-string id="Menu:POLMessages"/></rom-file>

--- a/PlayOnline.FFXI.Utils.DataBrowser/ROMFileMappings.xml
+++ b/PlayOnline.FFXI.Utils.DataBrowser/ROMFileMappings.xml
@@ -334,6 +334,10 @@
 	</category>
 	<category><name><region-name id="045"/></name>
 	</category>
+	<category><name><region-name id="047"/></name>
+		<rom-file id="06602"><area-name id="182"/></rom-file>
+		<rom-file id="06642"><area-name id="222"/></rom-file>
+	</category>
       </category>
       <category><name>&amp;<i18n-string id="FFXI9"/></name>
 	<category><name><region-name id="049"/></name>
@@ -373,7 +377,6 @@
 	<rom-file id="06636"><area-name id="216"/></rom-file>
 	<rom-file id="06465"><area-name id="045"/></rom-file>
 	<rom-file id="06637"><area-name id="217"/></rom-file>
-	<rom-file id="06602"><area-name id="182"/></rom-file>
 	<rom-file id="06673"><area-name id="253"/></rom-file>
 	<rom-file id="06674"><area-name id="254"/></rom-file>
 	<rom-file id="06675"><area-name id="255"/></rom-file>
@@ -399,7 +402,6 @@
 	<rom-file id="06464"><area-name id="044"/></rom-file>
 	<rom-file id="06603"><area-name id="183"/></rom-file>
 	<separator/>
-	<rom-file id="06642"><area-name id="222"/></rom-file>
 	<rom-file id="85619"><area-name id="285"/></rom-file>
 	<separator/>
 	<!-- NOTE: <area-name id="210"/> won't do because in the client this is blank,
@@ -739,6 +741,10 @@
 	</category>
 	<category><name><region-name id="045"/></name>
 	</category>
+	<category><name><region-name id="047"/></name>
+		<rom-file id="56467"><area-name id="182"/></rom-file>
+		<rom-file id="56507"><area-name id="222"/></rom-file>
+	</category>
       </category>
       <category><name><i18n-string id="Menu:Abyssea"/></name>
 	<rom-file id="56500"><area-name id="215"/></rom-file>
@@ -751,7 +757,6 @@
 	<rom-file id="56528"><area-name id="253"/></rom-file>
 	<rom-file id="56529"><area-name id="254"/></rom-file>
 	<rom-file id="56530"><area-name id="255"/></rom-file>
-	<rom-file id="56467"><area-name id="182"/></rom-file>
       </category>
       <category><name><i18n-string id="Menu:Other"/></name>
 	<rom-file id="56509"><area-name id="224"/></rom-file>
@@ -772,8 +777,6 @@
 	<rom-file id="56328"><area-name id="043"/></rom-file>
 	<rom-file id="56329"><area-name id="044"/></rom-file>
 	<rom-file id="56468"><area-name id="183"/></rom-file>
-	<separator/>
-	<rom-file id="56507"><area-name id="222"/></rom-file>
 	<separator/>
 	<rom-file id="56271"><i18n-string id="Menu:MonsterSkillNames"/></rom-file>
       </category>
@@ -1101,6 +1104,10 @@
 	</category>
 	<category><name><region-name id="045"/></name>
 	</category>
+	<category><name><region-name id="047"/></name>
+		<rom-file id="56047"><area-name id="182"/></rom-file>
+		<rom-file id="56087"><area-name id="222"/></rom-file>
+	</category>
       </category>
       <category><name><i18n-string id="Menu:Abyssea"/></name>
 	<rom-file id="56080"><area-name id="215"/></rom-file>
@@ -1113,7 +1120,6 @@
 	<rom-file id="56118"><area-name id="253"/></rom-file>
 	<rom-file id="56119"><area-name id="254"/></rom-file>
 	<rom-file id="56120"><area-name id="255"/></rom-file>
-	<rom-file id="56047"><area-name id="182"/></rom-file>
       </category>
       <category><name><i18n-string id="Menu:Other"/></name>
 	<rom-file id="56089"><area-name id="224"/></rom-file>
@@ -1134,8 +1140,6 @@
 	<rom-file id="55908"><area-name id="043"/></rom-file>
 	<rom-file id="55909"><area-name id="044"/></rom-file>
 	<rom-file id="56048"><area-name id="183"/></rom-file>
-	<separator/>
-	<rom-file id="56087"><area-name id="222"/></rom-file>
 	<separator/>
 	<rom-file id="55851"><i18n-string id="Menu:MonsterSkillNames"/></rom-file>
       </category>
@@ -1463,6 +1467,10 @@
 	</category>
 	<category><name><region-name id="045"/></name>
 	</category>
+	<category><name><region-name id="047"/></name>
+		<rom-file id="06302"><area-name id="182"/></rom-file>
+		<rom-file id="06342"><area-name id="222"/></rom-file>
+	</category>
       </category>
       <category><name><i18n-string id="Menu:Abyssea"/></name>
 	<rom-file id="06335"><area-name id="215"/></rom-file>
@@ -1475,7 +1483,6 @@
 	<rom-file id="06373"><area-name id="253"/></rom-file>
 	<rom-file id="06174"><area-name id="254"/></rom-file>
 	<rom-file id="06375"><area-name id="255"/></rom-file>
-	<rom-file id="06302"><area-name id="182"/></rom-file>
       </category>
       <category><name><i18n-string id="Menu:Other"/></name>
 	<rom-file id="06344"><area-name id="224"/></rom-file>
@@ -1496,8 +1503,6 @@
 	<rom-file id="06163"><area-name id="043"/></rom-file>
 	<rom-file id="06164"><area-name id="044"/></rom-file>
 	<rom-file id="06303"><area-name id="183"/></rom-file>
-	<separator/>
-	<rom-file id="06342"><area-name id="222"/></rom-file>
 	<separator/>
 	<rom-file id="07034"><i18n-string id="Menu:MonsterSkillNames"/></rom-file>
       </category>
@@ -2783,6 +2788,10 @@
       </category>
       <category><name><region-name id="045"/></name>
       </category>
+    <category><name><region-name id="047"/></name>
+        <rom-file id="06902"><area-name id="182"/></rom-file>
+        <rom-file id="06942"><area-name id="222"/></rom-file>
+    </category>
     </category>
     <category><name><i18n-string id="Menu:Abyssea"/></name>
       <rom-file id="06935"><area-name id="215"/></rom-file>
@@ -2795,7 +2804,6 @@
       <rom-file id="06973"><area-name id="253"/></rom-file>
       <rom-file id="06974"><area-name id="254"/></rom-file>
       <rom-file id="06975"><area-name id="255"/></rom-file>
-      <rom-file id="06902"><area-name id="182"/></rom-file>
     </category>
     <category><name>&amp;<i18n-string id="FFXI9"/></name>
      <category><name><region-name id="049"/></name>
@@ -2869,7 +2877,6 @@
       <rom-file id="06764"><area-name id="044"/></rom-file>
       <rom-file id="06903"><area-name id="183"/></rom-file>
       <separator/>
-      <rom-file id="06942"><area-name id="222"/></rom-file>
       <rom-file id="86520"><area-name id="285"/></rom-file>
       <separator/>
       <!-- NOTE: <area-name id="210"/> won't do because in the client this is blank,


### PR DESCRIPTION
Apologies for cramming mutliple things into 1 pull request here.
Added new Rhapsodies zones and a new category to hold them. Put "The Threshold" region into WotG's list and moved its zones into it. Added the mission lists for Rhapsodies. Did both English and Japanese, didn't touch French or German (thought those got removed from retail anyway..) and noticed I forgot to add the Japanese dialog table entry for GM Home, so got that as well.

I auto re-formatted your xml document, it was pretty messy which lead to a parsing error.
You will want to review this with whitespace set off by appending ?w=1 to the url.
If anyone is worried about git blame, you can disable whitespace comparing for that too.