### PR TITLE
Dialogs and entity lists for Mount Kamihr, fix typo for Leafalia

### DIFF
--- a/PlayOnline.FFXI.Utils.DataBrowser/ROMFileMappings.xml
+++ b/PlayOnline.FFXI.Utils.DataBrowser/ROMFileMappings.xml
@@ -379,7 +379,8 @@
                     <rom-file id="85610"><area-name id="275"/></rom-file>
                     <rom-file id="85611"><area-name id="276"/></rom-file>
                     <rom-file id="85612"><area-name id="277"/></rom-file>
-                    <rom-file id="86516"><area-name id="281"/></rom-file>
+                    <rom-file id="85616"><area-name id="281"/></rom-file>
+                    <rom-file id="85617"><area-name id="282"/></rom-file>
                 </category>
             </category>
             <category><name><i18n-string id="Rhapsodies of Vana'diel"/></name>
@@ -795,6 +796,7 @@
                     <rom-file id="?"><area-name id="276"/></rom-file>
                     <rom-file id="?"><area-name id="277"/></rom-file>
                     <rom-file id="?"><area-name id="281"/></rom-file>
+                    <rom-file id="?"><area-name id="282"/></rom-file>
                 </category>
                 -->
             </category>
@@ -1191,6 +1193,7 @@
                     <rom-file id="?"><area-name id="276"/></rom-file>
                     <rom-file id="?"><area-name id="277"/></rom-file>
                     <rom-file id="?"><area-name id="281"/></rom-file>
+                    <rom-file id="?"><area-name id="282"/></rom-file>
                 </category>
                 -->
             </category>
@@ -1587,6 +1590,7 @@
                     <rom-file id="?"><area-name id="276"/></rom-file>
                     <rom-file id="?"><area-name id="277"/></rom-file>
                     <rom-file id="?"><area-name id="281"/></rom-file>
+                    <rom-file id="?"><area-name id="282"/></rom-file>
                 </category>
                 -->
             </category>
@@ -2957,6 +2961,7 @@
                 <rom-file id="86511"><area-name id="276"/></rom-file>
                 <rom-file id="86512"><area-name id="277"/></rom-file>
                 <rom-file id="86516"><area-name id="281"/></rom-file>
+                <rom-file id="86517"><area-name id="282"/></rom-file>
             </category>
         </category>
         <category><name><i18n-string id="Rhapsodies of Vana'diel"/></name>


### PR DESCRIPTION
Added mount c'mere to dialog and entity lists (Thanks for spotting the NPC's dat file @deviltti) and fixed a typo in one of Leafalia's dat IDs.