### PR TITLE
fix InstinctCost switch case mistakenly loading ilevel data

### DIFF
--- a/PlayOnline.FFXI/Things/Item.cs
+++ b/PlayOnline.FFXI/Things/Item.cs
@@ -494,7 +494,7 @@ namespace PlayOnline.FFXI.Things
                     this.iLevel_ = (ushort)this.LoadUnsignedIntegerField(Node);
                     break;
                 case "instinct-cost:":
-                    this.iLevel_ = (ushort)this.LoadUnsignedIntegerField(Node);
+                    this.InstinctCost_ = (ushort)this.LoadUnsignedIntegerField(Node);
                     break;
                 case "jobs":
                     this.Jobs_ = (Job)this.LoadHexField(Node);


### PR DESCRIPTION
I assume you don't want item level data where instinct cost belongs.